### PR TITLE
Improve frontmatter for Jupyter links

### DIFF
--- a/.changeset/cuddly-camels-arrive.md
+++ b/.changeset/cuddly-camels-arrive.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/frontmatter': patch
+---
+
+Change subtitle to a paragraph lead, not a semantic heading

--- a/.changeset/empty-mangos-itch.md
+++ b/.changeset/empty-mangos-itch.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/frontmatter': patch
+---
+
+License icons should inherit text color

--- a/.changeset/spotty-brooms-speak.md
+++ b/.changeset/spotty-brooms-speak.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/frontmatter': patch
+---
+
+Empty license object should be hidden

--- a/.changeset/witty-houses-learn.md
+++ b/.changeset/witty-houses-learn.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/frontmatter': patch
+---
+
+Decrease spacing in author/date list

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -97,7 +97,7 @@ export function AuthorAndAffiliations({ authors }: { authors: PageFrontmatter['a
   );
   if (!hasAffliations) {
     return (
-      <header className="not-prose mb-10">
+      <header className="not-prose mb-2">
         {authors.length > 1 && <div className="font-thin text-xs uppercase pb-2">Authors</div>}
         {authors.map((author) => (
           <Author key={author.name} author={author} />
@@ -106,7 +106,7 @@ export function AuthorAndAffiliations({ authors }: { authors: PageFrontmatter['a
     );
   }
   return (
-    <header className="not-prose mb-10">
+    <header className="not-prose mb-2">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-y-1">
         {authors.length > 1 && (
           <>
@@ -137,6 +137,7 @@ export function AuthorAndAffiliations({ authors }: { authors: PageFrontmatter['a
                         target="_blank"
                         rel="noopener noreferrer"
                         title="ROR (Research Organization Registry)"
+                        className="text-inherit"
                       >
                         <RorIcon className="ml-2 inline-block h-[2em] w-[2em] grayscale hover:grayscale-0 -translate-y-[1px]" />
                       </a>
@@ -214,6 +215,7 @@ export function GitHubLink({ github: possibleLink }: { github?: string }) {
       title={`GitHub Repository: ${github}`}
       target="_blank"
       rel="noopener noreferrer"
+      className="text-inherit"
     >
       <GithubIcon className="w-5 h-5 mr-1 inline-block opacity-60 hover:opacity-100" />
     </a>
@@ -228,6 +230,7 @@ export function OpenAccessBadge({ open_access }: { open_access?: boolean }) {
       target="_blank"
       rel="noopener noreferrer"
       title="Open Access"
+      className="text-inherit"
     >
       <OpenAccessIcon className="w-5 h-5 mr-1 inline-block opacity-60 hover:opacity-100 hover:text-[#E18435]" />
     </a>
@@ -316,7 +319,7 @@ export function FrontmatterBlock({
       {authorStyle === 'list' && <AuthorsList authors={frontmatter.authors} />}
       {authorStyle === 'block' && <AuthorAndAffiliations authors={frontmatter.authors} />}
       {hasDateOrDoi && (
-        <div className="flex my-6 text-sm font-light">
+        <div className="flex my-2 text-sm font-light">
           <DateString date={date} spacer={!!doi} />
           <DoiBadge doi={doi} />
         </div>

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -312,9 +312,9 @@ export function FrontmatterBlock({
           <DownloadsDropdown exports={exports as any} />
         </div>
       )}
-      <h1 className={classNames('title', { 'mb-2': frontmatter.subtitle })}>{frontmatter.title}</h1>
+      <h1 className={classNames({ 'mb-2': frontmatter.subtitle })}>{frontmatter.title}</h1>
       {frontmatter.subtitle && (
-        <h2 className="title mt-0 text-zinc-600 dark:text-zinc-400">{frontmatter.subtitle}</h2>
+        <p className="lead mt-0 text-zinc-600 dark:text-zinc-400">{frontmatter.subtitle}</p>
       )}
       {authorStyle === 'list' && <AuthorsList authors={frontmatter.authors} />}
       {authorStyle === 'block' && <AuthorAndAffiliations authors={frontmatter.authors} />}

--- a/packages/frontmatter/src/licenses.tsx
+++ b/packages/frontmatter/src/licenses.tsx
@@ -34,10 +34,10 @@ export function CreativeCommonsBadge({
   const kind = match[1].toUpperCase();
   return (
     <a
-      className={classNames('opacity-50 hover:opacity-100', className)}
       href={license.url}
       target="_blank"
       rel="noopener noreferrer"
+      className={classNames('opacity-50 hover:opacity-100 text-inherit', className)}
     >
       <CcIcon className="h-5 w-5 mx-1 inline-block" title={`${title}`} />
       {(kind.startsWith('CC0') || kind.startsWith('CC-0') || kind.includes('ZERO')) && (
@@ -88,7 +88,7 @@ function SingleLicenseBadge({
     typeof possibleLicense === 'string'
       ? { name: '', url: '', id: possibleLicense }
       : possibleLicense;
-  if (!license) return null;
+  if (!license || Object.keys(license).length === 0) return null;
   if (license.CC) {
     return <CreativeCommonsBadge license={license} preamble={preamble} className={className} />;
   }
@@ -98,6 +98,7 @@ function SingleLicenseBadge({
       target="_blank"
       rel="noopener noreferrer"
       title={`${preamble}${license.name ?? (license as any).title} (${license.id})`}
+      className="text-inherit"
     >
       {!license.osi && (
         <ScaleIcon


### PR DESCRIPTION
The links in JupyterLab style are blue, and the icons should be text-colored.

Fixes #28