### PR TITLE
empty frontmatter title should not make h1

### DIFF
--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -317,7 +317,9 @@ export function FrontmatterBlock({
           <DownloadsDropdown exports={exports as any} />
         </div>
       )}
-      <h1 className={classNames({ 'mb-2': frontmatter.subtitle })}>{frontmatter.title}</h1>
+      {frontmatter.title && (
+        <h1 className={classNames({ 'mb-2': frontmatter.subtitle })}>{frontmatter.title}</h1>
+      )}
       {frontmatter.subtitle && (
         <p className="lead mt-0 text-zinc-600 dark:text-zinc-400">{frontmatter.subtitle}</p>
       )}


### PR DESCRIPTION
Fixes a case that may have been uncommon but is more likely when https://github.com/executablebooks/mystjs/issues/281 is done.