### PR TITLE
🎨  Fix line break and space rendering and align directive margin for code blocks

### DIFF
--- a/.changeset/brown-carpets-drop.md
+++ b/.changeset/brown-carpets-drop.md
@@ -1,0 +1,6 @@
+---
+'myst-to-react': patch
+'@myst-theme/jupyter': patch
+---
+
+Improve the rendering of code outputs in jupyter

--- a/packages/jupyter/src/safe.tsx
+++ b/packages/jupyter/src/safe.tsx
@@ -59,7 +59,7 @@ function SafeOutput({ output }: { output: MinifiedOutput }) {
       if (image) return <OutputImage image={image} text={text} />;
       if (text)
         return (
-          <div>
+          <div className="whitespace-pre-wrap font-mono text-sm">
             <Ansi>{text.content}</Ansi>
           </div>
         );

--- a/packages/myst-to-react/src/code.tsx
+++ b/packages/myst-to-react/src/code.tsx
@@ -34,7 +34,7 @@ export function CodeBlock(props: Props) {
   } = props;
   const highlightLines = new Set(emphasizeLines);
   const borderClass =
-    'rounded shadow-md dark:shadow-2xl dark:shadow-neutral-900 my-8 text-sm border border-l-4 border-l-blue-400 border-gray-200 dark:border-l-blue-400 dark:border-gray-800';
+    'rounded shadow-md dark:shadow-2xl dark:shadow-neutral-900 my-4 text-sm border border-l-4 border-l-blue-400 border-gray-200 dark:border-l-blue-400 dark:border-gray-800';
   return (
     <div
       className={classNames('relative group not-prose overflow-auto', className, {


### PR DESCRIPTION
Hi, I find when we render the text with `\n` and space, it will only be considered as single space since the default html behavior. I have a quick fix. The reason we use the font-mono is we have to keep the original character width the same to copy with some formatted output like NumPy array and pandas Series. Besides, the current margin for the code blocks is too big, and I checked the directive block margin is m-4, thus it much better to change this for unified visual experience. @rowanc1 

Here is the contrast:

<img src="https://user-images.githubusercontent.com/41546976/229333523-c6f67f14-a48e-42a5-be85-5eaeae5aaf4a.png"  width="40%">
---------------------------------
<img src="https://user-images.githubusercontent.com/41546976/229333527-07860f18-b187-42d5-918f-f23bfd9754d1.png"  width="40%">

Thanks!