### PR TITLE
[FIX] wrap gridded content in div for block display

### DIFF
--- a/packages/site/src/components/ContentBlocks.tsx
+++ b/packages/site/src/components/ContentBlocks.tsx
@@ -41,13 +41,15 @@ function Block({
         [subGrid]: !noSubGrid,
       })}
     >
-      {children}
-      {isACodeCell(node) && (
-        <div className="hidden group-hover/block:flex md:flex-col absolute -top-[28px] md:top-0 right-0 md:-right-[28px] mt-8">
-          <RunCell id={id} />
-          <ClearCell id={id} />
-        </div>
-      )}
+      <div>
+        {children}
+        {isACodeCell(node) && (
+          <div className="hidden group-hover/block:flex md:flex-col absolute -top-[28px] md:top-0 right-0 md:-right-[28px] mt-8">
+            <RunCell id={id} />
+            <ClearCell id={id} />
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Hi @rowanc1 I really like what you've done for myst-based websites. The book theme looks great overall but I've run into a couple of quirks.

One is that paragraph margins are being doubled in the main content. The default margin is `1.25em` which seems reasonable but `2.5em` margins are actually displayed, which look enormous.

![image](https://github.com/executablebooks/myst-theme/assets/7685034/c2331ab6-e116-45bd-9113-963010dc1ff9)

It's because margins are not collapsing since the HTML has been put directly inside a container with `display:grid`.

I offer a very simple fix, wrapping the content in a `div` which naturally has `display:block`.
