### PR TITLE
🐛 Text color label for proof

### DIFF
--- a/.changeset/stupid-hounds-nail.md
+++ b/.changeset/stupid-hounds-nail.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Text color inherit for proof label

--- a/packages/myst-to-react/src/heading.tsx
+++ b/packages/myst-to-react/src/heading.tsx
@@ -36,7 +36,7 @@ export function HashLink({
   };
   return (
     <a
-      className={classNames('select-none no-underline', className, {
+      className={classNames('select-none no-underline text-inherit hover:text-inherit', className, {
         'transition-opacity opacity-0 group-hover:opacity-70': hover,
         'hover:underline': !hover,
       })}


### PR DESCRIPTION
This fixes jupyterlab, which overrides the text color for links, and it makes the hash-links a inherited color (rather than blue).

![image](https://github.com/executablebooks/myst-theme/assets/913249/7e505ca3-4a59-4049-af66-36697cd25729)
