### PR TITLE
🐼 Drop pandas table margin to get consistent with default zero margin thebe-output block

### DIFF
--- a/styles/jupyter.css
+++ b/styles/jupyter.css
@@ -9,13 +9,15 @@
   display: none;
 }
 /* Pandas tables */
-.dataframe table {
+/* Here we use important to overwrite mt from typography.css */
+table.dataframe {
   border: none;
   border-collapse: collapse;
   border-spacing: 0;
   color: black;
   font-size: 1em;
   table-layout: fixed;
+  margin: 0 !important;
 }
 .dataframe thead {
   border-bottom: 1px solid black;


### PR DESCRIPTION
Currently, if table element margin is decided by typography.css:
https://github.com/executablebooks/myst-theme/blob/6404d386efb39b7f8024813f2000a816974f1f7a/styles/typography.css#L46
Since apply on `prose`, it will have mt-5 style:
https://github.com/executablebooks/myst-theme/blob/6404d386efb39b7f8024813f2000a816974f1f7a/styles/typography.css#L20
However, since DataFrame, which appear in the thebe-output is also a table element, the margin is inconsistent with default thebe-output block, having zero margin, like the numpy output in the following example:
![10 06 2023_21 22 17_REC](https://github.com/executablebooks/myst-theme/assets/41546976/f7831111-feb6-4d44-90e1-30c7d56b8a60)
It would be better if we align the m-0 behavior:
![10 06 2023_21 28 38_REC](https://github.com/executablebooks/myst-theme/assets/41546976/fc5adb73-891f-47b8-8b22-fe13558c693f)