### PR TITLE
🐛 Footer links in single project mode

### DIFF
--- a/.changeset/eight-buckets-whisper.md
+++ b/.changeset/eight-buckets-whisper.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': patch
+---
+
+Footer links for single project mode

--- a/packages/site/src/loaders/utils.ts
+++ b/packages/site/src/loaders/utils.ts
@@ -72,7 +72,7 @@ export function getFooterLinks(
   projectSlug?: string,
   slug?: string,
 ): FooterLinks {
-  if (!projectSlug || !slug || !config) return {};
+  if (!slug || !config) return {};
   const pages = getProjectHeadings(config, projectSlug, {
     addGroups: true,
   });


### PR DESCRIPTION
This brings back footer links when there is only a single project.