### PR TITLE
⛺️ `thebe` async loading uses `BASE_URL`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36146,9 +36146,9 @@
       "dev": true
     },
     "node_modules/thebe-core": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/thebe-core/-/thebe-core-0.2.3.tgz",
-      "integrity": "sha512-i6TASRAVITrzF+YSGF7V/a9aIZHfp7yRXNOYNWODfPRwigXhGooEJwPehzctevLC/4aJgYNkmKQlAcNVexg4sw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/thebe-core/-/thebe-core-0.2.5.tgz",
+      "integrity": "sha512-dcR5lHZCedt3FfJlatGtcZ/d+u266OofrqMZ5LqlrQl02or40nAbaCVBmruJl73sgP2PIv4mB7eTX/LN+hjmgw==",
       "dependencies": {
         "@jupyter-widgets/base": "^6.0.1",
         "@jupyter-widgets/controls": "^5.0.1",
@@ -36169,8 +36169,11 @@
         "lodash.merge": "^4.6.2",
         "nanoid": "^3.2.0"
       },
+      "bin": {
+        "copy-thebe-assets": "bin/copy-thebe-assets.cjs"
+      },
       "peerDependencies": {
-        "thebe-lite": "^0.2.3"
+        "thebe-lite": "^0.2.5"
       }
     },
     "node_modules/thebe-core/node_modules/nanoid": {
@@ -36191,9 +36194,9 @@
       }
     },
     "node_modules/thebe-lite": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/thebe-lite/-/thebe-lite-0.2.3.tgz",
-      "integrity": "sha512-T2YKkqXuc2DVi/3V4n0urciNuaDC9SF3CDRaWoxdRS1YB5vNdPabCbHSzVD6lIY5kcjNaocy3O+HIiGJKPKhHw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/thebe-lite/-/thebe-lite-0.2.5.tgz",
+      "integrity": "sha512-37Ol5+cmYT6h9gcyp06TeZtGVD6ECRqs+OF0r7ZiGYpwAvlYj728bJSrtLvNWRDvTA9HOdS7Lz5qlKhAoJt9kw==",
       "dependencies": {
         "@jupyterlab/coreutils": "^5.6.3",
         "@jupyterlite/pyodide-kernel": "0.0.8",
@@ -36204,14 +36207,14 @@
       }
     },
     "node_modules/thebe-react": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/thebe-react/-/thebe-react-0.2.3.tgz",
-      "integrity": "sha512-Xknt8mOEmk3xhPqV1aMJ7/kXbTG/AByb/WT6TGWs7XuEipMJyrz8pBOa6aH0WZCKXLGQfs46Inm5JbaCriHYvA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/thebe-react/-/thebe-react-0.2.5.tgz",
+      "integrity": "sha512-Zm3aPvthzqzj98Q8/aT44N6eUB3ea6ok5JaK1dJDcO0P7kKpGWLD5EKi9pzfc8vgR6DxyIGTignmb+7MRh7Pzg==",
       "dependencies": {
         "@jupyterlab/nbformat": "^3.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "thebe-core": "^0.2.3"
+        "thebe-core": "^0.2.5"
       }
     },
     "node_modules/thenify": {
@@ -38966,9 +38969,9 @@
         "nbtx": "^0.2.3",
         "react-syntax-highlighter": "^15.5.0",
         "swr": "^2.1.5",
-        "thebe-core": "^0.2.3",
-        "thebe-lite": "^0.2.3",
-        "thebe-react": "^0.2.3",
+        "thebe-core": "^0.2.5",
+        "thebe-lite": "^0.2.5",
+        "thebe-react": "^0.2.5",
         "unist-util-select": "^4.0.3"
       },
       "devDependencies": {},
@@ -39160,7 +39163,7 @@
         "nbtx": "^0.2.3",
         "node-cache": "^5.1.2",
         "node-fetch": "^2.6.11",
-        "thebe-react": "^0.2.3",
+        "thebe-react": "^0.2.5",
         "unist-util-select": "^4.0.1"
       },
       "devDependencies": {

--- a/packages/jupyter/package.json
+++ b/packages/jupyter/package.json
@@ -34,9 +34,9 @@
     "nbtx": "^0.2.3",
     "react-syntax-highlighter": "^15.5.0",
     "swr": "^2.1.5",
-    "thebe-core": "^0.2.3",
-    "thebe-lite": "^0.2.3",
-    "thebe-react": "^0.2.3",
+    "thebe-core": "^0.2.5",
+    "thebe-lite": "^0.2.5",
+    "thebe-react": "^0.2.5",
     "unist-util-select": "^4.0.3"
   },
   "peerDependencies": {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -29,7 +29,7 @@
     "nbtx": "^0.2.3",
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.11",
-    "thebe-react": "^0.2.3",
+    "thebe-react": "^0.2.5",
     "unist-util-select": "^4.0.1"
   },
   "peerDependencies": {

--- a/packages/site/src/pages/Root.tsx
+++ b/packages/site/src/pages/Root.tsx
@@ -60,10 +60,10 @@ export function Document({
           analytics_plausible={config?.analytics_plausible}
         />
       </head>
-      <body className="m-0 bg-white transition-colors duration-500 dark:bg-stone-900">
+      <body className="m-0 transition-colors duration-500 bg-white dark:bg-stone-900">
         <ThemeProvider theme={theme} renderers={renderers} {...links}>
           <BaseUrlProvider baseurl={baseurl}>
-            <ThebeBundleLoaderProvider loadThebeLite>
+            <ThebeBundleLoaderProvider loadThebeLite publicPath={baseurl}>
               <SiteProvider config={config}>
                 <ConfiguredThebeServerProvider>{children}</ConfiguredThebeServerProvider>
               </SiteProvider>
@@ -90,6 +90,7 @@ export function App() {
 
 export function AppWithReload() {
   const { theme, config, CONTENT_CDN_PORT, MODE, BASE_URL } = useLoaderData<SiteLoader>();
+  console.log('AppWithReload', { BASE_URL });
   return (
     <Document
       theme={theme}

--- a/packages/site/src/pages/Root.tsx
+++ b/packages/site/src/pages/Root.tsx
@@ -90,7 +90,6 @@ export function App() {
 
 export function AppWithReload() {
   const { theme, config, CONTENT_CDN_PORT, MODE, BASE_URL } = useLoaderData<SiteLoader>();
-  console.log('AppWithReload', { BASE_URL });
   return (
     <Document
       theme={theme}


### PR DESCRIPTION
This should fix https://github.com/executablebooks/mystjs/issues/441 by using the correct `BASE_URL`.

- [x] Tested locally both with and without the BASE_URL in normal operation (nr theme:book + headless content).
- [x] Tested locally with a static build (by copying over the deployable theme into a _build folder)
- [x] Tested on githuhbpages (https://github.com/stevejpurves/myst-online-media-testing, https://stevejpurves.github.io/myst-online-media-testing/)

I could not get a local static build or manual deployment to gh-pages working (the [docs](https://mystmd.org/guide/deployment#deploying-to-github-pages) could be clearer about where to set the env var in the non-action local build case... locally? or in an env var on github?)