### PR TITLE
⌥ adding `hide_footer` and wiring up `hide_toc` in article theme

### DIFF
--- a/.changeset/lemon-penguins-draw.md
+++ b/.changeset/lemon-penguins-draw.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/article': patch
+---
+
+Add `hide_footer` template options and make both `hide_footer` and `hide_toc` take effect.

--- a/themes/article/app/routes/$slug.tsx
+++ b/themes/article/app/routes/$slug.tsx
@@ -64,6 +64,11 @@ export function ArticlePageAndNavigation({
   );
 }
 
+interface ArticleTemplateOptions {
+  hide_toc?: boolean;
+  hide_footer?: boolean;
+}
+
 function ArticleNavigation() {
   const site = useSiteManifest();
   const Link = useLinkProvider();
@@ -71,6 +76,7 @@ function ArticleNavigation() {
   const { pathname } = useLocation();
   const project = site?.projects?.[0];
   const exact = pathname === `/`;
+
   return (
     <nav className="col-page-inset">
       <div className="flex flex-row justify-around py-3 mt-4 mb-6 border-gray-200 border-y">
@@ -145,7 +151,8 @@ export function Article({ article }: { article: PageLoader }) {
 }
 
 export function ArticlePage({ article }: { article: PageLoader }) {
-  const { projects } = useSiteManifest() ?? {};
+  const { projects, hide_toc, hide_footer } = (useSiteManifest() ?? {}) as SiteManifest &
+    ArticleTemplateOptions;
   return (
     <ReferencesProvider
       references={{ ...article.references, article: article.mdast }}
@@ -160,11 +167,11 @@ export function ArticlePage({ article }: { article: PageLoader }) {
             />
             {/* <Actions /> */}
           </section>
-          <ArticleNavigation />
+          {!hide_toc && <ArticleNavigation />}
           <main className="article-grid article-subgrid-gap col-screen">
             <Article article={article} />
           </main>
-          <FooterLinksBlock links={article.footer} />
+          {!hide_footer && <FooterLinksBlock links={article.footer} />}
         </ExecuteScopeProvider>
       </BusyScopeProvider>
     </ReferencesProvider>
@@ -174,9 +181,10 @@ export function ArticlePage({ article }: { article: PageLoader }) {
 export default function Page({ top = DEFAULT_NAV_HEIGHT }: { top?: number }) {
   // const { container, outline } = useOutlineHeight();
   const article = useLoaderData<PageLoader>() as PageLoader;
-  const { hide_outline, hide_toc } = (article.frontmatter as any)?.design ?? {};
+  const { hide_outline } = (article.frontmatter as any)?.design ?? {};
+
   return (
-    <ArticlePageAndNavigation hide_toc={hide_toc}>
+    <ArticlePageAndNavigation>
       <ArticlePage article={article} />
       {/* {!hide_outline && <DocumentOutline outlineRef={outline} top={top} height={height} />} */}
     </ArticlePageAndNavigation>

--- a/themes/article/template.yml
+++ b/themes/article/template.yml
@@ -16,6 +16,9 @@ options:
   - type: boolean
     id: hide_toc
     description: Hide the table of contents
+  - type: boolean
+    id: hide_footer
+    description: Hide the previous/next button footer
   - type: string
     id: twitter
     description: Twitter handle related to the site


### PR DESCRIPTION
Adds options making the article an even more single page experience by removing the TOC and footer navigations.