### PR TITLE
🔭 compute controls no longer shown when thebe not enabled

### DIFF
--- a/.changeset/fuzzy-beans-study.md
+++ b/.changeset/fuzzy-beans-study.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/jupyter': patch
+'@myst-theme/site': patch
+---
+
+Hide compute controls and figure decoration when thebe is not enabled but still show minimal links to source notebooks.

--- a/packages/jupyter/src/BinderBadge.tsx
+++ b/packages/jupyter/src/BinderBadge.tsx
@@ -60,7 +60,7 @@ function BinderBadgeLogo() {
 export function BinderBadge({ binder }: { binder?: string }) {
   if (!binder) return null;
   return (
-    <div className="inline-block mr-1 opacity-80 hover:opacity-100">
+    <div className="inline-block m-1 opacity-80 hover:opacity-100">
       <a
         href={binder}
         title={`Launch Binder Session: ${binder}`}

--- a/packages/jupyter/src/embed.tsx
+++ b/packages/jupyter/src/embed.tsx
@@ -20,14 +20,14 @@ function EmbedWithControls({
   title?: string;
   url?: string;
 }) {
-  const { kind } = useCellExecution(outputKey);
+  const { canCompute, kind } = useCellExecution(outputKey);
   const Link = useLinkProvider();
   const baseurl = useBaseurl();
-  const showControls = kind === SourceFileKind.Article;
+  const showComputeControls = canCompute && kind === SourceFileKind.Article;
 
-  return (
-    <div className="shadow">
-      {showControls && (
+  if (showComputeControls) {
+    return (
+      <div className="shadow">
         <div className="sticky top-[60px] z-[2] w-full bg-gray-100/80 backdrop-blur dark:bg-neutral-800/80 py-1 px-2">
           <div className="flex items-center">
             <div className="flex items-center">
@@ -48,8 +48,29 @@ function EmbedWithControls({
             <ArticleResetNotebook id={outputKey} />
           </div>
         </div>
-      )}
-      <div className="mt-2">{children}</div>
+        <div className="mt-2">{children}</div>
+      </div>
+    );
+  }
+
+  // light
+  return (
+    <div>
+      <div className="sticky top-[60px] z-[2] w-full backdrop-blur py-1 px-2">
+        <div className="mt-2">{children}</div>
+        <div className="flex items-center justify-end text-xs">
+          <JupyterIcon className="inline-block w-3 h-3" />
+          <div className="ml-1">Source:</div>
+          {url && (
+            <Link
+              to={withBaseurl(url, baseurl)}
+              className="ml-1 no-underline text-normal hover:underline"
+            >
+              {title}
+            </Link>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/jupyter/src/embed.tsx
+++ b/packages/jupyter/src/embed.tsx
@@ -55,8 +55,8 @@ function EmbedWithControls({
 
   // light
   return (
-    <div className="z-[2] w-full backdrop-blur py-1 px-2">
-      <div className="mt-2">{children}</div>
+    <>
+      {children}
       <div className="flex items-center justify-end text-xs">
         <JupyterIcon className="inline-block w-3 h-3" />
         <div className="ml-1">Source:</div>
@@ -69,7 +69,7 @@ function EmbedWithControls({
           </Link>
         )}
       </div>
-    </div>
+    </>
   );
 }
 

--- a/packages/jupyter/src/embed.tsx
+++ b/packages/jupyter/src/embed.tsx
@@ -55,21 +55,19 @@ function EmbedWithControls({
 
   // light
   return (
-    <div>
-      <div className="sticky top-[60px] z-[2] w-full backdrop-blur py-1 px-2">
-        <div className="mt-2">{children}</div>
-        <div className="flex items-center justify-end text-xs">
-          <JupyterIcon className="inline-block w-3 h-3" />
-          <div className="ml-1">Source:</div>
-          {url && (
-            <Link
-              to={withBaseurl(url, baseurl)}
-              className="ml-1 no-underline text-normal hover:underline"
-            >
-              {title}
-            </Link>
-          )}
-        </div>
+    <div className="z-[2] w-full backdrop-blur py-1 px-2">
+      <div className="mt-2">{children}</div>
+      <div className="flex items-center justify-end text-xs">
+        <JupyterIcon className="inline-block w-3 h-3" />
+        <div className="ml-1">Source:</div>
+        {url && (
+          <Link
+            to={withBaseurl(url, baseurl)}
+            className="ml-1 no-underline text-normal hover:underline"
+          >
+            {title}
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/packages/jupyter/src/execute/hooks.ts
+++ b/packages/jupyter/src/execute/hooks.ts
@@ -284,6 +284,7 @@ export function useCellExecution(id: IdOrKey) {
   const notebookIsBusy = notebookIsExecuting || notebookIsResetting;
 
   return {
+    canCompute: context.canCompute,
     kind,
     ready,
     execute,

--- a/packages/jupyter/src/execute/provider.tsx
+++ b/packages/jupyter/src/execute/provider.tsx
@@ -14,6 +14,7 @@ import {
 } from './selectors';
 import { MdastFetcher, NotebookBuilder, ServerMonitor, SessionStarter } from './leaf';
 import { useCanCompute } from '..';
+import type { Thebe } from 'myst-frontmatter';
 
 export interface ExecuteScopeType {
   canCompute: boolean;
@@ -30,7 +31,7 @@ type ArticleContents = {
   kind: SourceFileKind;
   mdast: Root;
   dependencies?: Dependency[];
-  frontmatter: { thebe?: Record<string, any> };
+  frontmatter: { thebe?: boolean | Thebe };
 };
 
 function useScopeNavigate({

--- a/packages/jupyter/src/execute/provider.tsx
+++ b/packages/jupyter/src/execute/provider.tsx
@@ -13,8 +13,10 @@ import {
   selectSessionsToStart,
 } from './selectors';
 import { MdastFetcher, NotebookBuilder, ServerMonitor, SessionStarter } from './leaf';
+import { useCanCompute } from '..';
 
 export interface ExecuteScopeType {
+  canCompute: boolean;
   slug: string;
   state: ExecuteScopeState;
   dispatch: React.Dispatch<ExecuteScopeAction>;
@@ -28,6 +30,7 @@ type ArticleContents = {
   kind: SourceFileKind;
   mdast: Root;
   dependencies?: Dependency[];
+  frontmatter: { thebe?: Record<string, any> };
 };
 
 function useScopeNavigate({
@@ -99,6 +102,7 @@ export function ExecuteScopeProvider({
   children,
   contents,
 }: React.PropsWithChildren<{ contents: ArticleContents }>) {
+  const canCompute = useCanCompute(contents);
   // compute incoming for first render
   const computables: Computable[] = selectAll('container > embed', contents.mdast).map(
     (node: any) => {
@@ -144,7 +148,7 @@ export function ExecuteScopeProvider({
     selectSessionsToStart(state);
 
   const memo = React.useMemo(
-    () => ({ slug: contents.slug, state, dispatch, idkmap: idkmap.current }),
+    () => ({ canCompute, slug: contents.slug, state, dispatch, idkmap: idkmap.current }),
     [state, contents.slug],
   );
 

--- a/packages/jupyter/src/providers.tsx
+++ b/packages/jupyter/src/providers.tsx
@@ -21,14 +21,18 @@ export function useComputeOptions() {
       binderBadgeUrl,
     );
     return {
-      canCompute: thebeFrontmatter !== undefined && thebeFrontmatter !== false,
-      thebe: thebeOptions,
+      thebe: thebeFrontmatter ? thebeOptions : undefined,
       githubBadgeUrl,
       binderBadgeUrl,
     };
   };
 
   return React.useMemo(makeOptions, [config]);
+}
+
+export function useCanCompute(article: { frontmatter: { thebe?: boolean | Record<string, any> } }) {
+  const { thebe } = useComputeOptions();
+  return !!thebe && (article.frontmatter as any)?.thebe !== false;
 }
 
 export function ConfiguredThebeServerProvider({ children }: React.PropsWithChildren) {

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -13,16 +13,17 @@ import {
   NotebookToolbar,
   ConnectionStatusTray,
   BinderBadge,
+  useCanCompute,
 } from '@myst-theme/jupyter';
 import { FrontmatterBlock } from '@myst-theme/frontmatter';
 
 export const ArticlePage = React.memo(function ({ article }: { article: PageLoader }) {
-  const computeOptions = useComputeOptions();
-  const canCompute = computeOptions.canCompute && (article.frontmatter as any)?.thebe !== false;
+  const canCompute = useCanCompute(article);
+  const { binderBadgeUrl } = useComputeOptions();
   const { hide_title_block, hide_footer_links } = (article.frontmatter as any)?.design ?? {};
 
   // take binder url from article frontmatter or fallback to project
-  const binderUrl = article.frontmatter.binder ?? computeOptions.binderBadgeUrl;
+  const binderUrl = article.frontmatter.binder ?? binderBadgeUrl;
 
   return (
     <ReferencesProvider


### PR DESCRIPTION
addresses #148 and https://github.com/executablebooks/mystmd/issues/461 with some concession to minimally altering the narritive/reading experience, while still keeping a reference link to the source notebook when thebe is not activated.

![image](https://github.com/executablebooks/myst-theme/assets/1473646/0cefd17a-ac5d-4621-9fde-2a76dfedb998)
