### PR TITLE
🪐☀️ Dark mode for Jupyter widgets

### DIFF
--- a/styles/jupyter.css
+++ b/styles/jupyter.css
@@ -43,3 +43,24 @@ table.dataframe {
 .dataframe tbody tr:hover {
   background: rgba(66, 165, 245, 0.2);
 }
+
+html.dark {
+  /* Defaults use Material Design specification */
+  --jp-ui-font-color0: rgba(255, 255, 255, 1);
+  --jp-ui-font-color1: rgba(255, 255, 255, 0.87);
+  --jp-ui-font-color2: rgba(255, 255, 255, 0.54);
+  --jp-ui-font-color3: rgba(255, 255, 255, 0.38);
+  --jp-ui-inverse-font-color0: rgba(0, 0, 0, 1);
+  --jp-ui-inverse-font-color1: rgba(0, 0, 0, 0.8);
+  --jp-ui-inverse-font-color2: rgba(0, 0, 0, 0.5);
+  --jp-ui-inverse-font-color3: rgba(0, 0, 0, 0.3);
+  --jp-content-font-color0: rgba(255, 255, 255, 1);
+  --jp-content-font-color1: rgba(255, 255, 255, 1);
+  --jp-content-font-color2: rgba(255, 255, 255, 0.7);
+  --jp-content-font-color3: rgba(255, 255, 255, 0.5);
+  --jp-layout-color0: #111;
+  --jp-layout-color1: var(--md-grey-900);
+  --jp-layout-color2: var(--md-grey-800);
+  --jp-layout-color3: var(--md-grey-700);
+  --jp-layout-color4: var(--md-grey-600);
+}


### PR DESCRIPTION
This is minimum viable theme improvements for using thebe in dark mode. I think it does belong here rather than in Thebe? But maybe not @stevejpurves?

![image](https://github.com/executablebooks/myst-theme/assets/913249/0ac949ef-5eb1-4607-8c4d-30f8a092f0c1)

![image](https://github.com/executablebooks/myst-theme/assets/913249/ce6cf690-d69a-47a6-9ea9-837ffcfdc044)
