### PR TITLE
📜 enable x-scrolling at figure level

### DIFF
--- a/.changeset/itchy-dogs-join.md
+++ b/.changeset/itchy-dogs-join.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/jupyter': patch
+---
+
+Changes overflow behaviour allowing horizontal scroll on outputs

--- a/packages/jupyter/src/output.tsx
+++ b/packages/jupyter/src/output.tsx
@@ -66,11 +66,14 @@ function JupyterOutput({
       id={identifier || undefined}
       data-mdast-node-type={nodeType}
       data-mdast-node-id={nodeKey}
-      className={classNames('max-w-full overflow-visible m-0 group not-prose relative', {
-        'text-left': !align || align === 'left',
-        'text-center': align === 'center',
-        'text-right': align === 'right',
-      })}
+      className={classNames(
+        'max-w-full overflow-y-visible overflow-x-auto m-0 group not-prose relative',
+        {
+          'text-left': !align || align === 'left',
+          'text-center': align === 'center',
+          'text-right': align === 'right',
+        },
+      )}
     >
       {component}
     </figure>


### PR DESCRIPTION
This change should immediately allow some outputs to be scrollable (e.g. plain text rendered as pre), in combination with [this change in thebe](https://github.com/executablebooks/thebe/pull/662) it should also allow output contents like wide pandas tables to scroll again.

![image](https://github.com/executablebooks/myst-theme/assets/1473646/963dfdab-101b-46fa-9f02-2fdd7aafe51d)
