### PR TITLE
🗂 Add files to theme's template.yml files

### DIFF
--- a/themes/article/template.yml
+++ b/themes/article/template.yml
@@ -40,3 +40,9 @@ options:
 build:
   install: npm install
   start: npm run start
+files:
+  - server.js
+  - package.json
+  - package-lock.json
+  - public/**/*
+  - build/**/*

--- a/themes/book/template.yml
+++ b/themes/book/template.yml
@@ -43,3 +43,9 @@ options:
 build:
   install: npm install
   start: npm run start
+files:
+  - server.js
+  - package.json
+  - package-lock.json
+  - public/**/*
+  - build/**/*


### PR DESCRIPTION
MyST templates changed how they download site themes (download/unzip instead of clone). This means we need to explicitly list required files. However! That's pretty easy because glob patters are now supported.

Corresponding mystjs pr: https://github.com/executablebooks/mystmd/pull/494