### PR TITLE
🏞 Fix placeholders when outputs are empty

### DIFF
--- a/.changeset/beige-mice-attend.md
+++ b/.changeset/beige-mice-attend.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/jupyter': patch
+---
+
+Placeholders are now displayed in figures that embed notebook cells with empty outputs

--- a/packages/jupyter/src/output.tsx
+++ b/packages/jupyter/src/output.tsx
@@ -6,6 +6,8 @@ import { SafeOutputs } from './safe';
 import { JupyterOutputs } from './jupyter';
 import { useMemo } from 'react';
 import { useCellExecution } from './execute';
+import { usePlaceholder } from './decoration';
+import { MyST } from 'myst-to-react';
 
 export const DIRECT_OUTPUT_TYPES = new Set(['stream', 'error']);
 
@@ -51,9 +53,15 @@ export function JupyterOutput({
     () => allOutputsAreSafe(outputs, DIRECT_OUTPUT_TYPES, DIRECT_MIME_TYPES),
     [outputs],
   );
+  const placeholder = usePlaceholder();
 
   let component;
   if (allSafe && !ready) {
+    if (placeholder && (!outputs || outputs.length === 0)) {
+      if (placeholder) {
+        return <MyST ast={placeholder} />;
+      }
+    }
     component = <SafeOutputs keyStub={outputId} outputs={outputs} />;
   } else {
     component = <JupyterOutputs id={outputId} outputs={outputs} />;


### PR DESCRIPTION
When an embedded notebook cell cell had no outputs it was deemed as "safe" and placehodlers were not being rendered.