### PR TITLE
🐦  Show author's Twitter account next to ORCID and email

### DIFF
--- a/.changeset/bright-lobsters-draw.md
+++ b/.changeset/bright-lobsters-draw.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/frontmatter': patch
+---
+
+Add twitter icon to authors

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -231,8 +231,6 @@ export function TwitterLink({ twitter: possibleLink }: { twitter?: string }) {
     </a>
   );
 }
-
-
 export function GitHubLink({ github: possibleLink }: { github?: string }) {
   if (!possibleLink) return null;
   const github = possibleLink.replace(/^(https?:\/\/)?github\.com\//, '');

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -231,6 +231,7 @@ export function TwitterLink({ twitter: possibleLink }: { twitter?: string }) {
     </a>
   );
 }
+
 export function GitHubLink({ github: possibleLink }: { github?: string }) {
   if (!possibleLink) return null;
   const github = possibleLink.replace(/^(https?:\/\/)?github\.com\//, '');

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -9,6 +9,7 @@ import {
   GithubIcon,
   EmailIcon,
   RorIcon,
+  TwitterIcon,
 } from '@scienceicons/react/24/solid';
 import { LicenseBadges } from './licenses';
 import { DownloadsDropdown } from './downloads';
@@ -63,6 +64,16 @@ export function Author({
           <OrcidIcon className="w-4 h-4 inline-block text-gray-400 hover:text-[#A9C751] -translate-y-[0.1em]" />
         </a>
       )}
+      {author.twitter && (
+        <a
+          className="ml-1"
+          href={`https://twitter.com/${author.twitter}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={`Twitter: ${author.twitter}`}
+        >
+          <TwitterIcon className="w-4 h-4 inline-block text-gray-400 hover:text-[#1DA1F2] -translate-y-[0.1em]" />
+        </a>
     </span>
   );
 }
@@ -203,6 +214,23 @@ export function DateString({
     </time>
   );
 }
+
+export function TwitterLink({ twitter: possibleLink }: { twitter?: string }) {
+  if (!possibleLink) return null;
+  const twitter = possibleLink.replace(/^(https?:\/\/)?twitter\.com\//, '');
+  return (
+    <a
+      href={`https://twitter.com/${twitter}`}
+      title={`Twitter: ${twitter}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-inherit hover:text-inherit"
+    >
+      <TwitterIcon className="inline-block w-5 h-5 mr-1 opacity-60 hover:opacity-100" />
+    </a>
+  );
+}
+
 
 export function GitHubLink({ github: possibleLink }: { github?: string }) {
   if (!possibleLink) return null;

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -74,6 +74,7 @@ export function Author({
         >
           <TwitterIcon className="w-4 h-4 inline-block text-gray-400 hover:text-[#1DA1F2] -translate-y-[0.1em]" />
         </a>
+      )}
     </span>
   );
 }


### PR DESCRIPTION
Closes none.

This PR allows adding an author's Twitter account next to their ORCID and email.

The Twitter account has to be added to the author's list in `index.md` for the book theme or `myst.yml` for the article theme. Here's an example:

```yaml
authors:
  - name: Eneko Uruñuela
    affiliations:
      - Basque Center on Cognition, Brain and Language, Donostia - San Sebastián, Spain
      - University of the Basque Country (EHU/UPV), Donostia-San Sebastián, Spain
    orcid: 0000-0001-6849-9088
    email: e.urunuela@bcbl.eu
    twitter: eurunuela
```