### PR TITLE
🎨 Update icon sizes to be explicit

### DIFF
--- a/.changeset/quick-apes-crash.md
+++ b/.changeset/quick-apes-crash.md
@@ -1,0 +1,10 @@
+---
+'myst-to-react': patch
+'@myst-theme/frontmatter': patch
+'myst-demo': patch
+'@myst-theme/jupyter': patch
+'@myst-theme/article': patch
+'@myst-theme/site': patch
+---
+
+Update icon sizes to be explicit rather than class names

--- a/packages/frontmatter/src/Authors.tsx
+++ b/packages/frontmatter/src/Authors.tsx
@@ -21,7 +21,11 @@ export function Author({
           target="_blank"
           rel="noopener noreferrer"
         >
-          <EmailIcon className="w-4 h-4 inline-block text-gray-400 hover:text-blue-400 -translate-y-[0.1em]" />
+          <EmailIcon
+            width="1rem"
+            height="1rem"
+            className="inline-block text-gray-400 hover:text-blue-400 -translate-y-[0.1em]"
+          />
         </a>
       )}
       {author.orcid && (
@@ -32,7 +36,11 @@ export function Author({
           rel="noopener noreferrer"
           title="ORCID (Open Researcher and Contributor ID)"
         >
-          <OrcidIcon className="w-4 h-4 inline-block text-gray-400 hover:text-[#A9C751] -translate-y-[0.1em]" />
+          <OrcidIcon
+            width="1rem"
+            height="1rem"
+            className="inline-block text-gray-400 hover:text-[#A9C751] -translate-y-[0.1em]"
+          />
         </a>
       )}
       {author.twitter && (
@@ -43,7 +51,11 @@ export function Author({
           rel="noopener noreferrer"
           title={`Twitter: ${author.twitter}`}
         >
-          <TwitterIcon className="w-4 h-4 inline-block text-gray-400 hover:text-[#1DA1F2] -translate-y-[0.1em]" />
+          <TwitterIcon
+            width="1rem"
+            height="1rem"
+            className="inline-block text-gray-400 hover:text-[#1DA1F2] -translate-y-[0.1em]"
+          />
         </a>
       )}
     </span>

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -93,7 +93,11 @@ export function TwitterLink({ twitter: possibleLink }: { twitter?: string }) {
       rel="noopener noreferrer"
       className="text-inherit hover:text-inherit"
     >
-      <TwitterIcon className="inline-block w-5 h-5 mr-1 opacity-60 hover:opacity-100" />
+      <TwitterIcon
+        width="1.25rem"
+        height="1.25rem"
+        className="inline-block mr-1 opacity-60 hover:opacity-100"
+      />
     </a>
   );
 }
@@ -109,7 +113,11 @@ export function GitHubLink({ github: possibleLink }: { github?: string }) {
       rel="noopener noreferrer"
       className="text-inherit hover:text-inherit"
     >
-      <GithubIcon className="inline-block w-5 h-5 mr-1 opacity-60 hover:opacity-100" />
+      <GithubIcon
+        width="1.25rem"
+        height="1.25rem"
+        className="inline-block mr-1 opacity-60 hover:opacity-100"
+      />
     </a>
   );
 }
@@ -124,7 +132,11 @@ export function OpenAccessBadge({ open_access }: { open_access?: boolean }) {
       title="Open Access"
       className="text-inherit hover:text-inherit"
     >
-      <OpenAccessIcon className="w-5 h-5 mr-1 inline-block opacity-60 hover:opacity-100 hover:text-[#E18435]" />
+      <OpenAccessIcon
+        width="1.25rem"
+        height="1.25rem"
+        className="mr-1 inline-block opacity-60 hover:opacity-100 hover:text-[#E18435]"
+      />
     </a>
   );
 }
@@ -226,7 +238,7 @@ export function FrontmatterBlock({
               <GitHubLink github={github} />
               {isJupyter && (
                 <div className="inline-block mr-1">
-                  <JupyterIcon className="inline-block w-5 h-5" />
+                  <JupyterIcon width="1.25rem" height="1.25rem" className="inline-block" />
                 </div>
               )}
             </>

--- a/packages/frontmatter/src/downloads.tsx
+++ b/packages/frontmatter/src/downloads.tsx
@@ -78,7 +78,12 @@ export function Download({
   return (
     <a className={classNames(className, 'flex')} href={url} onClick={clickDownload}>
       <span className="sr-only">Download as {format}</span>
-      <DocumentIcon className="items-center inline-block w-5 h-5 mr-2" aria-hidden="true" />
+      <DocumentIcon
+        width="1.25rem"
+        height="1.25rem"
+        className="items-center inline-block mr-2"
+        aria-hidden="true"
+      />
       {filename}
     </a>
   );
@@ -90,7 +95,12 @@ export function DownloadsDropdown({ exports }: HasExports) {
     <Menu as="div" className="relative flex inline-block mx-1 grow-0">
       <Menu.Button className="relative">
         <span className="sr-only">Downloads</span>
-        <ArrowDownTrayIcon className="w-5 h-5 ml-2 -mr-1" aria-hidden="true" />
+        <ArrowDownTrayIcon
+          width="1.25rem"
+          height="1.25rem"
+          className="ml-2 -mr-1"
+          aria-hidden="true"
+        />
       </Menu.Button>
       <Menu.Items className="absolute overflow-hidden bg-white rounded-sm shadow-lg -right-1 dark:bg-slate-800 ring-1 ring-black ring-opacity-5 focus:outline-none">
         {exports.map(({ format, filename, url }, index) => (

--- a/packages/frontmatter/src/licenses.tsx
+++ b/packages/frontmatter/src/licenses.tsx
@@ -43,34 +43,44 @@ export function CreativeCommonsBadge({
       )}
       aria-label={title}
     >
-      <CcIcon className="inline-block w-5 h-5 mx-1" title={title} />
+      <CcIcon width="1.25rem" height="1.25rem" className="inline-block mx-1" title={title} />
       {(kind.startsWith('CC0') || kind.startsWith('CC-0') || kind.includes('ZERO')) && (
         <CcZeroIcon
-          className="inline-block w-5 h-5 mr-1"
+          width="1.25rem"
+          height="1.25rem"
+          className="inline-block mr-1"
           title="CC0: Work is in the worldwide public domain"
         />
       )}
       {kind.includes('BY') && (
         <CcByIcon
-          className="inline-block w-5 h-5 mr-1"
+          width="1.25rem"
+          height="1.25rem"
+          className="inline-block mr-1"
           title="Credit must be given to the creator"
         />
       )}
       {kind.includes('NC') && (
         <CcNcIcon
-          className="inline-block w-5 h-5 mr-1"
+          width="1.25rem"
+          height="1.25rem"
+          className="inline-block mr-1"
           title="Only noncommercial uses of the work are permitted"
         />
       )}
       {kind.includes('SA') && (
         <CcSaIcon
-          className="inline-block w-5 h-5 mr-1"
+          width="1.25rem"
+          height="1.25rem"
+          className="inline-block mr-1"
           title="Adaptations must be shared under the same terms"
         />
       )}
       {kind.includes('ND') && (
         <CcNdIcon
-          className="inline-block w-5 h-5 mr-1"
+          width="1.25rem"
+          height="1.25rem"
+          className="inline-block mr-1"
           title="No derivatives or adaptations of the work are permitted"
         />
       )}
@@ -106,16 +116,17 @@ function SingleLicenseBadge({
     >
       {!license.osi && (
         <ScaleIcon
-          className={classNames(
-            'h-5 w-5 mx-1 inline-block opacity-60 hover:opacity-100',
-            className,
-          )}
+          width="1.25rem"
+          height="1.25rem"
+          className={classNames('mx-1 inline-block opacity-60 hover:opacity-100', className)}
         />
       )}
       {license.osi && (
         <OsiIcon
+          width="1.25rem"
+          height="1.25rem"
           className={classNames(
-            'h-5 w-5 mx-1 inline-block opacity-60 hover:opacity-100 hover:text-[#599F46]',
+            'mx-1 inline-block opacity-60 hover:opacity-100 hover:text-[#599F46]',
             className,
           )}
         />

--- a/packages/jupyter/src/controls/Buttons.tsx
+++ b/packages/jupyter/src/controls/Buttons.tsx
@@ -25,12 +25,12 @@ export function SpinnerStatusButton({
     title = modified ? 'The figure has been modified' : "The figure is in it's original state";
   }
 
-  let icon = <PowerIcon className="w-6 h-6" />;
+  let icon = <PowerIcon width="1.5rem" height="1.5rem" />;
   if (ready) {
     if (modified) {
-      icon = <Bolt className="w-6 h-6 text-green-600" />;
+      icon = <Bolt width="1.5rem" height="1.5rem" className="text-green-600" />;
     } else {
-      icon = <BoltIconSolid className="w-6 h-6 text-green-600" />;
+      icon = <BoltIconSolid width="1.5rem" height="1.5rem" className="text-green-600" />;
     }
   }
 
@@ -52,8 +52,8 @@ export function SpinnerStatusButton({
         {icon}
       </button>
       {busy && (
-        <span className="absolute top-0 left-0 z-10 w-[22px] h-[22px] opacity-100">
-          <Spinner size={24} />
+        <span className="absolute top-0 left-0 z-10 opacity-100">
+          <Spinner size={22} />
         </span>
       )}
     </div>
@@ -93,8 +93,8 @@ function SpinnerButton({
         {icon}
       </button>
       {busy && (
-        <span className="absolute top-0 left-0 z-10 w-[22px] h-[22px] opacity-100">
-          <Spinner size={24} />
+        <span className="absolute top-0 left-0 z-10 opacity-100">
+          <Spinner size={22} />
         </span>
       )}
     </div>
@@ -121,7 +121,7 @@ export function Run({
       disabled={disabled}
       title={title ?? 'run all cells'}
       onClick={onClick}
-      icon={<PlayCircleIcon className="inline-block w-6 h-6 align-top" />}
+      icon={<PlayCircleIcon width="1.5rem" height="1.5rem" className="inline-block align-top" />}
     />
   );
 }
@@ -146,7 +146,13 @@ export function Power({
       disabled={disabled}
       title={title ?? 'enable compute'}
       onClick={onClick}
-      icon={<PowerIcon className="inline-block w-6 h-6 align-top dark:text-white" />}
+      icon={
+        <PowerIcon
+          width="1.5rem"
+          height="1.5rem"
+          className="inline-block align-top dark:text-white"
+        />
+      }
     />
   );
 }
@@ -171,7 +177,7 @@ export function ReRun({
       disabled={disabled}
       title={title ?? 'run all cells'}
       onClick={onClick}
-      icon={<ArrowPathIcon className="inline-block w-6 h-6 align-top" />}
+      icon={<ArrowPathIcon width="1.5rem" height="1.5rem" className="inline-block align-top" />}
     />
   );
 }
@@ -196,7 +202,7 @@ export function Reset({
       disabled={disabled}
       title={title ?? 'reset notebook'}
       onClick={onClick}
-      icon={<ArrowUturnLeft className="inline-block w-6 h-6 align-top" />}
+      icon={<ArrowUturnLeft width="1.5rem" height="1.5rem" className="inline-block align-top" />}
     />
   );
 }
@@ -223,7 +229,7 @@ export function Clear({
       title={title ?? 'clear'}
       aria-label={title ?? 'clear'}
     >
-      <MinusCircleIcon className="inline-block w-6 h-6 align-top" />
+      <MinusCircleIcon width="1.5rem" height="1.5rem" className="inline-block align-top" />
     </button>
   );
 }
@@ -247,7 +253,11 @@ export function Launch({
       title={title ?? 'launch in jupyter'}
       aria-label={title ?? 'launch in jupyter'}
     >
-      <ArrowTopRightOnSquareIcon className="inline-block w-6 h-6 align-top" />
+      <ArrowTopRightOnSquareIcon
+        width="1.5rem"
+        height="1.5rem"
+        className="inline-block align-top"
+      />
     </button>
   );
 }

--- a/packages/jupyter/src/controls/Spinner.tsx
+++ b/packages/jupyter/src/controls/Spinner.tsx
@@ -3,7 +3,9 @@ export function Spinner({ size }: { size: number }) {
     <div role="status">
       <svg
         aria-hidden="true"
-        className={`w-[${size}px] h-[${size}px] mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-green-600`}
+        width={size}
+        height={size}
+        className="mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-green-600"
         viewBox="0 0 100 101"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/jupyter/src/decoration.tsx
+++ b/packages/jupyter/src/decoration.tsx
@@ -49,7 +49,7 @@ export function OutputDecoration({
         <div className="sticky top-[60px] z-[2] w-full bg-gray-100/80 backdrop-blur dark:bg-neutral-800/80 py-1 px-2">
           <div className="flex items-center">
             <div className="flex items-center">
-              <JupyterIcon className="inline-block w-5 h-5" />
+              <JupyterIcon width="1.25rem" height="1.25rem" className="inline-block" />
               <span className="ml-2">Source:</span>
               {url && (
                 <Link
@@ -76,7 +76,7 @@ export function OutputDecoration({
     return (
       <>
         <div className="flex items-center justify-end text-xs">
-          <JupyterIcon className="inline-block w-3 h-3" />
+          <JupyterIcon width="0.75rem" height="0.75rem" className="inline-block" />
           <div className="ml-1">Source:</div>
           {url && (
             <Link

--- a/packages/myst-demo/src/index.tsx
+++ b/packages/myst-demo/src/index.tsx
@@ -343,7 +343,8 @@ export function MySTRenderer({
                 title={`Download Micorsoft Word`}
                 aria-label={`Download Micorsoft Word`}
               >
-                <ArrowDownTrayIcon className="inline h-[1.3em] mr-1" /> Download as Microsoft Word
+                <ArrowDownTrayIcon width="1.3rem" height="1.3rem" className="inline mr-1" />{' '}
+                Download as Microsoft Word
               </button>
             </div>
           )}
@@ -359,9 +360,15 @@ export function MySTRenderer({
                   'bg-slate-500 dark:bg-slate-800': m.fatal === null,
                 })}
               >
-                {m.fatal === true && <ExclamationCircleIcon className="inline h-[1.3em] mr-1" />}
-                {m.fatal === false && <ExclamationTriangleIcon className="inline h-[1.3em] mr-1" />}
-                {m.fatal === null && <InformationCircleIcon className="inline h-[1.3em] mr-1" />}
+                {m.fatal === true && (
+                  <ExclamationCircleIcon width="1.3rem" height="1.3rem" className="inline mr-1" />
+                )}
+                {m.fatal === false && (
+                  <ExclamationTriangleIcon width="1.3rem" height="1.3rem" className="inline mr-1" />
+                )}
+                {m.fatal === null && (
+                  <InformationCircleIcon width="1.3rem" height="1.3rem" className="inline mr-1" />
+                )}
                 <code>{m.ruleId || m.source}</code>: {m.message}
               </div>
             ))}

--- a/packages/myst-to-react/src/admonitions.tsx
+++ b/packages/myst-to-react/src/admonitions.tsx
@@ -90,21 +90,22 @@ function getFirstKind({
   return { kind: AdmonitionKind.note, color: 'blue' };
 }
 
-const iconClass = 'h-8 w-8 inline-block pl-2 mr-2 self-center flex-none';
+const iconClass = 'inline-block pl-2 mr-2 self-center flex-none';
 
 function AdmonitionIcon({ kind, className }: { kind: AdmonitionKind; className?: string }) {
   const cn = classNames(iconClass, className);
-  if (kind === AdmonitionKind.note) return <InformationCircleIcon className={cn} />;
-  if (kind === AdmonitionKind.caution) return <OExclamationIcon className={cn} />;
-  if (kind === AdmonitionKind.warning) return <SExclamationIcon className={cn} />;
-  if (kind === AdmonitionKind.danger) return <SExclamationCircleIcon className={cn} />;
-  if (kind === AdmonitionKind.error) return <XCircleIcon className={cn} />;
-  if (kind === AdmonitionKind.attention) return <MegaphoneIcon className={cn} />;
-  if (kind === AdmonitionKind.tip) return <PencilSquareIcon className={cn} />;
-  if (kind === AdmonitionKind.hint) return <LightBulbIcon className={cn} />;
-  if (kind === AdmonitionKind.important) return <BoltIcon className={cn} />;
-  if (kind === AdmonitionKind.seealso) return <ArrowRightCircleIcon className={cn} />;
-  return <InformationCircleIcon className={cn} />;
+  const opts = { width: '2rem', height: '2rem', className: cn };
+  if (kind === AdmonitionKind.note) return <InformationCircleIcon {...opts} />;
+  if (kind === AdmonitionKind.caution) return <OExclamationIcon {...opts} />;
+  if (kind === AdmonitionKind.warning) return <SExclamationIcon {...opts} />;
+  if (kind === AdmonitionKind.danger) return <SExclamationCircleIcon {...opts} />;
+  if (kind === AdmonitionKind.error) return <XCircleIcon {...opts} />;
+  if (kind === AdmonitionKind.attention) return <MegaphoneIcon {...opts} />;
+  if (kind === AdmonitionKind.tip) return <PencilSquareIcon {...opts} />;
+  if (kind === AdmonitionKind.hint) return <LightBulbIcon {...opts} />;
+  if (kind === AdmonitionKind.important) return <BoltIcon {...opts} />;
+  if (kind === AdmonitionKind.seealso) return <ArrowRightCircleIcon {...opts} />;
+  return <InformationCircleIcon {...opts} />;
 }
 
 export const AdmonitionTitle: NodeRenderer<AdmonitionTitleSpec> = ({ node }) => {
@@ -209,6 +210,8 @@ export function Admonition({
           {dropdown && (
             <div className="self-center flex-none text-sm font-thin text-neutral-700 dark:text-neutral-200">
               <ChevronRightIcon
+                width="2rem"
+                height="2rem"
                 className={classNames(iconClass, 'transition-transform details-toggle')}
               />
             </div>

--- a/packages/myst-to-react/src/components/CopyIcon.tsx
+++ b/packages/myst-to-react/src/components/CopyIcon.tsx
@@ -29,9 +29,9 @@ export function CopyIcon({ text, className }: { text: string; className?: string
       aria-label="Copy code to clipboard"
     >
       {copied ? (
-        <CheckIcon className="w-[24px] h-[24px] text-success" />
+        <CheckIcon width={24} height={24} className="text-success" />
       ) : (
-        <DocumentDuplicateIcon className="w-[24px] h-[24px]" />
+        <DocumentDuplicateIcon width={24} height={24} />
       )}
     </button>
   );

--- a/packages/myst-to-react/src/components/LinkCard.tsx
+++ b/packages/myst-to-react/src/components/LinkCard.tsx
@@ -48,7 +48,7 @@ export function LinkCard({
           target="_blank"
           rel="noreferrer"
         >
-          <ExternalLinkIcon className="float-right w-4 h-4" />
+          <ExternalLinkIcon width="1rem" height="1rem" className="float-right" />
           {title}
         </a>
       )}

--- a/packages/myst-to-react/src/dropdown.tsx
+++ b/packages/myst-to-react/src/dropdown.tsx
@@ -12,7 +12,7 @@ type SummarySpec = {
   type: 'summary';
 };
 
-const iconClass = 'h-8 w-8 inline-block pl-2 mr-2 -translate-y-[1px]';
+const iconClass = 'inline-block pl-2 mr-2 -translate-y-[1px]';
 
 export const SummaryTitle: NodeRenderer<SummarySpec> = ({ node }) => {
   return <MyST ast={node.children} />;
@@ -45,6 +45,8 @@ export function Details({
         <span className="text-neutral-900 dark:text-white">
           <span className="block float-right text-sm font-thin text-neutral-700 dark:text-neutral-200">
             <ChevronRightIcon
+              width="1.5rem"
+              height="1.5rem"
               className={classNames(iconClass, 'details-toggle', 'transition-transform')}
             />
           </span>

--- a/packages/myst-to-react/src/exercise.tsx
+++ b/packages/myst-to-react/src/exercise.tsx
@@ -71,7 +71,7 @@ const HeaderElement = ({
   return <div className={className}>{children}</div>;
 };
 
-const iconClass = 'h-8 w-8 inline-block pl-2 mr-2 self-center flex-none';
+const iconClass = 'inline-block pl-2 mr-2 self-center flex-none';
 
 export function Callout({
   title,
@@ -153,6 +153,8 @@ export function Callout({
         {dropdown && (
           <div className="self-center flex-none text-sm font-thin text-neutral-700 dark:text-neutral-200">
             <ChevronRightIcon
+              width="1.5rem"
+              height="1.5rem"
               className={classNames(iconClass, 'transition-transform details-toggle')}
             />
           </div>

--- a/packages/myst-to-react/src/inlineError.tsx
+++ b/packages/myst-to-react/src/inlineError.tsx
@@ -8,7 +8,7 @@ interface Props {
 export function InlineError({ value, message }: Props) {
   return (
     <span className="text-yellow-600" title={message || value}>
-      <ExclamationCircleIcon className="inline h-[1em] mr-1" />
+      <ExclamationCircleIcon width="1rem" height="1rem" className="inline mr-1" />
       {value}
     </span>
   );

--- a/packages/myst-to-react/src/links/github.tsx
+++ b/packages/myst-to-react/src/links/github.tsx
@@ -70,7 +70,7 @@ function GithubFilePreview({
           target="_blank"
           rel="noreferrer"
         >
-          <ExternalLinkIcon className="float-right w-4 h-4" />
+          <ExternalLinkIcon width="1rem" height="1rem" className="float-right" />
         </a>
         <div className="mt-2">Error loading "{file}" from GitHub.</div>
       </div>
@@ -181,10 +181,18 @@ function GithubIssuePreview({
       </div>
       <div className="my-2 text-lg font-bold dark:text-white">
         {resp.state === 'open' && (
-          <PlusCircleIcon className="inline-block w-6 h-6 mr-2 text-green-700 -translate-y-px dark:text-green-500" />
+          <PlusCircleIcon
+            width="1.5rem"
+            height="1.5rem"
+            className="inline-block mr-2 text-green-700 -translate-y-px dark:text-green-500"
+          />
         )}
         {resp.state === 'closed' && (
-          <CheckCircleIcon className="inline-block w-6 h-6 mr-2 text-purple-700 -translate-y-px dark:text-purple-500" />
+          <CheckCircleIcon
+            width="1.5rem"
+            height="1.5rem"
+            className="inline-block mr-2 text-purple-700 -translate-y-px dark:text-purple-500"
+          />
         )}
         {resp.title}
       </div>

--- a/packages/myst-to-react/src/links/index.tsx
+++ b/packages/myst-to-react/src/links/index.tsx
@@ -98,7 +98,7 @@ export const link: NodeRenderer<TransformedLink> = ({ node }) => {
 };
 
 export const linkBlock: NodeRenderer<TransformedLink> = ({ node }) => {
-  const iconClass = 'w-6 h-6 self-center transition-transform flex-none ml-3';
+  const iconClass = 'self-center transition-transform flex-none ml-3';
   const containerClass =
     'flex-1 p-4 my-5 block border font-normal hover:border-blue-500 dark:hover:border-blue-400 no-underline hover:text-blue-600 dark:hover:text-blue-400 text-gray-600 dark:text-gray-100 border-gray-200 dark:border-gray-500 rounded shadow-sm hover:shadow-lg dark:shadow-neutral-700';
   const internal = node.internal ?? false;
@@ -110,8 +110,8 @@ export const linkBlock: NodeRenderer<TransformedLink> = ({ node }) => {
           <MyST ast={node.children} />
         </div>
       </div>
-      {internal && <LinkIcon className={iconClass} />}
-      {!internal && <ExternalLinkIcon className={iconClass} />}
+      {internal && <LinkIcon width="1.5rem" height="1.5rem" className={iconClass} />}
+      {!internal && <ExternalLinkIcon width="1.5rem" height="1.5rem" className={iconClass} />}
     </div>
   );
 

--- a/packages/myst-to-react/src/links/wiki.tsx
+++ b/packages/myst-to-react/src/links/wiki.tsx
@@ -84,7 +84,7 @@ function WikiChild({ page, wiki, load }: { page: string; wiki: string; load: boo
           target="_blank"
           rel="noreferrer"
         >
-          <ExternalLinkIcon className="float-right w-4 h-4" />
+          <ExternalLinkIcon width="1rem" height="1rem" className="float-right" />
           <WikiTextMark />
         </a>
         <div className="mt-2">Error loading "{page}" from wikipedia.</div>

--- a/packages/myst-to-react/src/math.tsx
+++ b/packages/myst-to-react/src/math.tsx
@@ -41,7 +41,7 @@ const mathRenderer: NodeRenderer<MathLike> = ({ node }) => {
       return (
         <pre title={node.message}>
           <span className="text-red-500">
-            <ExclamationCircleIcon className="inline h-[1em] mr-1" />
+            <ExclamationCircleIcon width="1rem" height="1rem" className="inline mr-1" />
             {node.message}
             {'\n\n'}
           </span>

--- a/packages/myst-to-react/src/proof.tsx
+++ b/packages/myst-to-react/src/proof.tsx
@@ -108,7 +108,7 @@ const HeaderElement = ({
   return <div className={className}>{children}</div>;
 };
 
-const iconClass = 'h-8 w-8 inline-block pl-2 mr-2 self-center flex-none';
+const iconClass = 'inline-block pl-2 mr-2 self-center flex-none';
 
 export function Proof({
   title,
@@ -178,6 +178,8 @@ export function Proof({
         {dropdown && (
           <div className="self-center flex-none text-sm font-thin text-neutral-700 dark:text-neutral-200">
             <ChevronRightIcon
+              width="1.5rem"
+              height="1.5rem"
               className={classNames(iconClass, 'transition-transform details-toggle')}
             />
           </div>

--- a/packages/site/src/components/DocumentOutline.tsx
+++ b/packages/site/src/components/DocumentOutline.tsx
@@ -285,7 +285,11 @@ export function SupportingDocuments() {
                     })
                   }
                 >
-                  <DocumentChartBarIcon className="inline h-5 pr-2 shrink-0" />
+                  <DocumentChartBarIcon
+                    width="1.25rem"
+                    height="1.25rem"
+                    className="inline mr-2 shrink-0"
+                  />
                   <span>{p.short_title || p.title}</span>
                 </NavLink>
               </li>

--- a/packages/site/src/components/FooterLinksBlock.tsx
+++ b/packages/site/src/components/FooterLinksBlock.tsx
@@ -21,14 +21,22 @@ const FooterLink = ({
     >
       <div className="flex h-full align-middle">
         {right && (
-          <ArrowLeftIcon className="self-center w-6 h-6 transition-transform group-hover:-translate-x-1 shrink-0" />
+          <ArrowLeftIcon
+            width="1.5rem"
+            height="1.5rem"
+            className="self-center transition-transform group-hover:-translate-x-1 shrink-0"
+          />
         )}
         <div className={classNames('flex-grow', { 'text-right': right })}>
           <div className="text-xs text-gray-500 dark:text-gray-400">{group || ' '}</div>
           {short_title || title}
         </div>
         {!right && (
-          <ArrowRightIcon className="self-center w-6 h-6 transition-transform group-hover:translate-x-1 shrink-0" />
+          <ArrowRightIcon
+            width="1.5rem"
+            height="1.5rem"
+            className="self-center transition-transform group-hover:translate-x-1 shrink-0"
+          />
         )}
       </div>
     </Link>

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -80,7 +80,11 @@ function NavItem({ item }: { item: SiteNavItem }) {
       <div className="inline-block">
         <Menu.Button className="inline-flex items-center justify-center w-full py-1 mx-2 font-medium rounded-md text-md text-stone-900 dark:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75">
           <span>{item.title}</span>
-          <ChevronDownIcon className="w-5 h-5 ml-2 -mr-1 text-violet-200 hover:text-violet-100" />
+          <ChevronDownIcon
+            width="1.25rem"
+            height="1.25rem"
+            className="ml-2 -mr-1 text-violet-200 hover:text-violet-100"
+          />
         </Menu.Button>
       </div>
       <Transition
@@ -92,7 +96,7 @@ function NavItem({ item }: { item: SiteNavItem }) {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute w-48 py-1 mt-2 bg-white rounded-sm shadow-lg origin-top-left left-4 ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <Menu.Items className="absolute w-48 py-1 mt-2 origin-top-left bg-white rounded-sm shadow-lg left-4 ring-1 ring-black ring-opacity-5 focus:outline-none">
           {item.children?.map((action) => (
             <Menu.Item key={action.url}>
               {/* This is really ugly, BUT, the action needs to be defined HERE or the click away doesn't work for some reason */}
@@ -147,7 +151,7 @@ function ActionMenu({ actions }: { actions?: SiteManifest['actions'] }) {
         <Menu.Button className="flex text-sm bg-transparent rounded-full focus:outline-none">
           <span className="sr-only">Open Menu</span>
           <div className="flex items-center text-stone-200 hover:text-white">
-            <EllipsisVerticalIcon className="w-8 h-8 p-1" />
+            <EllipsisVerticalIcon width="2rem" height="2rem" className="p-1" />
           </div>
         </Menu.Button>
       </div>
@@ -160,7 +164,7 @@ function ActionMenu({ actions }: { actions?: SiteManifest['actions'] }) {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 w-48 py-1 mt-2 bg-white rounded-sm shadow-lg origin-top-right ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <Menu.Items className="absolute right-0 w-48 py-1 mt-2 origin-top-right bg-white rounded-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
           {actions?.map((action) => (
             <Menu.Item key={action.url}>
               {({ active }) => (
@@ -251,7 +255,7 @@ export function TopNav() {
                 setOpen(!open);
               }}
             >
-              <MenuIcon className="w-8 h-8 p-1" />
+              <MenuIcon width="2rem" height="2rem" className="m-1" />
               <span className="sr-only">Open Menu</span>
             </button>
           </div>

--- a/themes/article/app/routes/$.tsx
+++ b/themes/article/app/routes/$.tsx
@@ -190,7 +190,11 @@ export function ArticlePage({ article }: { article: PageLoader }) {
                   to={baseurl || '/'}
                   className="flex gap-1 px-2 py-1 font-normal no-underline border rounded bg-slate-200 border-slate-600 hover:bg-slate-800 hover:text-white hover:border-transparent"
                 >
-                  <ArrowLeftIcon className="self-center w-4 h-4 transition-transform group-hover:-translate-x-1 shrink-0" />
+                  <ArrowLeftIcon
+                    width="1rem"
+                    height="1rem"
+                    className="self-center transition-transform group-hover:-translate-x-1 shrink-0"
+                  />
                   <span>Back to Article</span>
                 </Link>
                 <div className="flex-grow text-center">{article.frontmatter.title}</div>
@@ -198,7 +202,11 @@ export function ArticlePage({ article }: { article: PageLoader }) {
                   href={article.frontmatter?.exports?.[0]?.url}
                   className="flex gap-1 px-2 py-1 font-normal no-underline border rounded bg-slate-200 border-slate-600 hover:bg-slate-800 hover:text-white hover:border-transparent"
                 >
-                  <DocumentArrowDownIcon className="self-center w-4 h-4 transition-transform group-hover:-translate-x-1 shrink-0" />
+                  <DocumentArrowDownIcon
+                    width="1rem"
+                    height="1rem"
+                    className="self-center transition-transform group-hover:-translate-x-1 shrink-0"
+                  />
                   <span>Download {article.kind}</span>
                 </a>
               </div>


### PR DESCRIPTION
This should be a no-op for the most part. However, when styles fail to load the experience is significantly better:

![image](https://github.com/executablebooks/myst-theme/assets/913249/0c7b1fa6-27bd-4b6b-8841-5d09e4e5e2ef)

Before it was a giant icon as the first thing that you see.