### PR TITLE
⌨️ Skip-to-content keyboard accessibility

### DIFF
--- a/.changeset/cold-pumpkins-wave.md
+++ b/.changeset/cold-pumpkins-wave.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+export HashLink

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -217,7 +217,11 @@ export function FrontmatterBlock({
     return null;
   }
   return (
-    <div className={classNames(className)}>
+    <div
+      id="skip-to-frontmatter"
+      aria-label="article frontmatter"
+      className={classNames(className)}
+    >
       {showHeaderBlock && (
         <div className="flex items-center h-6 mt-3 mb-5 text-sm font-light">
           {subject && (

--- a/packages/myst-to-react/src/heading.tsx
+++ b/packages/myst-to-react/src/heading.tsx
@@ -15,7 +15,7 @@ export function HashLink({
   hideInPopup,
 }: {
   id?: string;
-  kind: string;
+  kind?: string;
   title?: string;
   hover?: boolean;
   children?: '#' | '¶' | React.ReactNode;

--- a/packages/myst-to-react/src/index.tsx
+++ b/packages/myst-to-react/src/index.tsx
@@ -23,6 +23,7 @@ import UNKNOWN_MYST_RENDERERS from './unknown';
 
 export { CopyIcon, HoverPopover, Tooltip, LinkCard } from './components';
 export { CodeBlock } from './code';
+export { HashLink } from './heading';
 export { Admonition, AdmonitionKind } from './admonitions';
 export { Details } from './dropdown';
 export { TabSet, TabItem } from './tabs';

--- a/packages/site/src/components/Abstract.tsx
+++ b/packages/site/src/components/Abstract.tsx
@@ -1,14 +1,16 @@
 import type { GenericParent } from 'myst-common';
 import { ContentBlocks } from './ContentBlocks';
 import classNames from 'classnames';
+import { HashLink } from 'myst-to-react';
 
 export function Abstract({ content }: { content: GenericParent }) {
   if (!content) return <div className="hidden" aria-label="this article has no abstract" />;
   return (
     <>
-      <span className="mb-3 font-semibold" tabIndex={0}>
+      <h2 id="abstract" className="mb-3 text-base font-semibold group">
         Abstract
-      </span>
+        <HashLink id="abstract" title="Link to Abstract" hover className="ml-2" />
+      </h2>
       <div className="px-6 py-1 mb-3 rounded-sm bg-slate-50 dark:bg-slate-800">
         <ContentBlocks mdast={content} className="col-body" />
       </div>
@@ -26,7 +28,7 @@ export function Keywords({
   if (hideKeywords || !keywords || keywords.length === 0)
     return <div className="hidden" aria-label="this article has no keywords" />;
   return (
-    <div className="mb-10" tabIndex={0}>
+    <div className="mb-10 group">
       <span className="mr-2 font-semibold">Keywords:</span>
       {keywords.map((k, i) => (
         <span
@@ -38,6 +40,7 @@ export function Keywords({
           {k}
         </span>
       ))}
+      <HashLink id="keywords" title="Link to Keywords" hover className="ml-2" />
     </div>
   );
 }

--- a/packages/site/src/components/Abstract.tsx
+++ b/packages/site/src/components/Abstract.tsx
@@ -3,10 +3,12 @@ import { ContentBlocks } from './ContentBlocks';
 import classNames from 'classnames';
 
 export function Abstract({ content }: { content: GenericParent }) {
-  if (!content) return null;
+  if (!content) return <div className="hidden" aria-label="this article has no abstract" />;
   return (
     <>
-      <span className="mb-3 font-semibold">Abstract</span>
+      <span className="mb-3 font-semibold" tabIndex={0}>
+        Abstract
+      </span>
       <div className="px-6 py-1 mb-3 rounded-sm bg-slate-50 dark:bg-slate-800">
         <ContentBlocks mdast={content} className="col-body" />
       </div>
@@ -21,9 +23,10 @@ export function Keywords({
   keywords?: string[];
   hideKeywords?: boolean;
 }) {
-  if (hideKeywords || !keywords || keywords.length === 0) return null;
+  if (hideKeywords || !keywords || keywords.length === 0)
+    return <div className="hidden" aria-label="this article has no keywords" />;
   return (
-    <div className="mb-10">
+    <div className="mb-10" tabIndex={0}>
       <span className="mr-2 font-semibold">Keywords:</span>
       {keywords.map((k, i) => (
         <span

--- a/packages/site/src/components/SkipToArticle.tsx
+++ b/packages/site/src/components/SkipToArticle.tsx
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+
+function makeSkipClickHander(hash: string) {
+  return (e: React.UIEvent<HTMLElement, Event>) => {
+    e.preventDefault();
+    const el = document.querySelector(`#${hash}`);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth' });
+    history.replaceState(undefined, '', `#${hash}`);
+    (el.nextSibling as HTMLElement).focus({ preventScroll: true });
+    (e.target as HTMLElement).blur();
+  };
+}
+
+export function SkipToArticle({
+  frontmatter = true,
+  article = true,
+}: {
+  frontmatter?: boolean;
+  article?: boolean;
+}) {
+  const fm = 'skip-to-frontmatter';
+  const art = 'skip-to-article';
+
+  const frontmatterHander = useCallback(() => makeSkipClickHander(fm), [frontmatter]);
+  const articleHandler = useCallback(() => makeSkipClickHander(art), [article]);
+  return (
+    <div
+      className="fixed top-1 left-1 h-[0px] w-[0px] focus-within:z-40 focus-within:h-auto focus-within:w-auto bg-white overflow-hidden focus-within:p-2 focus-within:ring-1"
+      aria-label="skip to content options"
+    >
+      {frontmatter && (
+        <a
+          href={`#${fm}`}
+          className="block px-2 py-1 text-black underline"
+          onClick={frontmatterHander}
+        >
+          Skip to frontmatter
+        </a>
+      )}
+      {article && (
+        <a
+          href={`#${art}`}
+          className="block px-2 py-1 text-black underline"
+          onClick={articleHandler}
+        >
+          Skip to article content
+        </a>
+      )}
+    </div>
+  );
+}

--- a/packages/site/src/components/SkipToArticle.tsx
+++ b/packages/site/src/components/SkipToArticle.tsx
@@ -35,7 +35,7 @@ export function SkipToArticle({
           className="block px-2 py-1 text-black underline"
           onClick={frontmatterHander}
         >
-          Skip to frontmatter
+          Skip to article frontmatter
         </a>
       )}
       {article && (

--- a/packages/site/src/components/index.ts
+++ b/packages/site/src/components/index.ts
@@ -8,3 +8,4 @@ export { Abstract, Keywords } from './Abstract';
 export { ExternalOrInternalLink } from './ExternalOrInternalLink';
 export * from './Navigation';
 export { renderers } from './renderers';
+export * from './SkipToArticle';

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -60,6 +60,7 @@ export const ArticlePage = React.memo(function ({
           )}
           {canCompute && article.kind === SourceFileKind.Notebook && <NotebookToolbar showLaunch />}
           <ErrorTray pageSlug={article.slug} />
+          <div id="skip-to-article" />
           <Abstract content={abstract as GenericParent} />
           {abstract && <Keywords keywords={keywords} hideKeywords={hideKeywords} />}
           <ContentBlocks pageKind={article.kind} mdast={tree as GenericParent} />

--- a/themes/article/app/root.tsx
+++ b/themes/article/app/root.tsx
@@ -9,6 +9,7 @@ import {
   getMetaTagsForSite,
   getThemeSession,
   ContentReload,
+  SkipToArticle,
 } from '@myst-theme/site';
 import { Outlet, useLoaderData } from '@remix-run/react';
 export { AppCatchBoundary as CatchBoundary } from '@myst-theme/site';
@@ -62,6 +63,7 @@ export default function AppWithReload() {
       baseurl={BASE_URL}
       top={0}
     >
+      <SkipToArticle frontmatter={false} />
       <Outlet />
     </Document>
   );

--- a/themes/article/app/routes/$.tsx
+++ b/themes/article/app/routes/$.tsx
@@ -147,6 +147,7 @@ export function Article({
               </DocumentOutline>
             </div>
           )}
+          <div id="skip-to-article" />
           <Abstract content={abstract as GenericParent} />
           <Keywords keywords={keywords} hideKeywords={hideKeywords} />
           <ContentBlocks mdast={tree as GenericParent} />

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -9,6 +9,7 @@ import {
   getMetaTagsForSite,
   getThemeSession,
   ContentReload,
+  SkipToArticle,
 } from '@myst-theme/site';
 import { Outlet, useLoaderData } from '@remix-run/react';
 export { AppCatchBoundary as CatchBoundary } from '@myst-theme/site';
@@ -61,6 +62,7 @@ export default function AppWithReload() {
       staticBuild={MODE === 'static'}
       baseurl={BASE_URL}
     >
+      <SkipToArticle />
       <Outlet />
     </Document>
   );


### PR DESCRIPTION
Addresses #231 

This can still be improved a lot but fulfills the basic need, a keyboard focus jumps ahead of nav and frontmatter.

![lazSNANApT](https://github.com/executablebooks/myst-theme/assets/1473646/d7e849e8-a434-4083-bf23-5949f1584c7c)

![bu49m8EYV0](https://github.com/executablebooks/myst-theme/assets/1473646/c576d386-4b4d-431d-9af8-094d714e4755)


There are some remaining issues:

* all themes - the page does not scroll as desired on use of the links on first page load, maybe fighting with other scroll restore behaviour?
* article theme - skip to supporting documents would be a good addition
