### PR TITLE
🐛 Navigation clicking in book theme

### DIFF
--- a/.changeset/giant-owls-matter.md
+++ b/.changeset/giant-owls-matter.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': patch
+---
+
+Fix z-index bug from a11y reordering

--- a/packages/site/src/components/Navigation/TableOfContents.tsx
+++ b/packages/site/src/components/Navigation/TableOfContents.tsx
@@ -168,8 +168,7 @@ export const TableOfContents = ({
         'fixed',
         `xl:${grid}`, // for example, xl:article-grid
         'grid-gap xl:w-screen xl:pointer-events-none overflow-auto max-xl:min-w-[300px]',
-        { hidden: !open },
-        { 'z-30': open },
+        { hidden: !open, 'z-30': open, 'z-10': !open },
       )}
       style={{ top }}
     >


### PR DESCRIPTION
The reordering in some of the accessibility changes required a z-index fix for pages with navigation content.

cc @stevejpurves