### PR TITLE
🕴 Hover CSS improvement for Remix v2

### DIFF
--- a/.changeset/four-seas-wink.md
+++ b/.changeset/four-seas-wink.md
@@ -1,0 +1,6 @@
+---
+'myst-to-react': patch
+'@myst-theme/styles': patch
+---
+
+Change the hover-document css to get around downstream error

--- a/packages/myst-to-react/src/cite.tsx
+++ b/packages/myst-to-react/src/cite.tsx
@@ -9,7 +9,7 @@ import { MyST } from './MyST.js';
 function CiteChild({ html }: { html?: string }) {
   return (
     <div
-      className="hover-document w-[500px] sm:max-w-[500px] p-3"
+      className="hover-document article w-[500px] sm:max-w-[500px] p-3"
       dangerouslySetInnerHTML={{ __html: html || '' }}
     />
   );

--- a/packages/myst-to-react/src/crossReference.tsx
+++ b/packages/myst-to-react/src/crossReference.tsx
@@ -207,7 +207,7 @@ export function CrossReferenceHover({
     <HoverPopover
       card={({ load }) => (
         <XRefProvider remote={remote} url={url} dataUrl={dataUrl}>
-          <div className="hover-document w-[500px] sm:max-w-[500px] px-3">
+          <div className="hover-document article w-[500px] sm:max-w-[500px] px-3">
             <XrefChildren
               load={load}
               remote={remote}

--- a/packages/myst-to-react/src/footnotes.tsx
+++ b/packages/myst-to-react/src/footnotes.tsx
@@ -11,7 +11,7 @@ function FootnoteDefinition({ identifier }: { identifier: string }) {
     select(`footnoteDefinition[identifier=${identifier}]`, references?.article);
   return (
     <XRefProvider>
-      <div className="hover-document w-[500px] sm:max-w-[500px] px-3">
+      <div className="hover-document article w-[500px] sm:max-w-[500px] px-3">
         <MyST ast={node.children} />
       </div>
     </XRefProvider>

--- a/packages/myst-to-react/src/links/github.tsx
+++ b/packages/myst-to-react/src/links/github.tsx
@@ -65,7 +65,7 @@ function GithubFilePreview({
   let code = data;
   if (error) {
     return (
-      <div className="hover-document w-[500px] sm:max-w-[500px]">
+      <div className="hover-document article w-[500px] sm:max-w-[500px]">
         <a
           href={url}
           className="block text-inherit hover:text-inherit"
@@ -118,7 +118,7 @@ function GithubFilePreview({
       url={url}
       title={`GitHub - ${org}/${repo}`}
       description={description}
-      className="hover-document max-w-[80vw]"
+      className="hover-document article max-w-[80vw]"
     />
   );
 }
@@ -152,13 +152,15 @@ function GithubIssuePreview({
   );
   if (!data && !error) {
     return (
-      <div className="hover-document w-[500px] sm:max-w-[500px] animate-pulse">Loading...</div>
+      <div className="hover-document article w-[500px] sm:max-w-[500px] animate-pulse">
+        Loading...
+      </div>
     );
   }
   const resp = data as unknown as Record<string, any>;
   if (error) {
     return (
-      <div className="hover-document">
+      <div className="hover-document article">
         <a
           href={url}
           className="block text-inherit hover:text-inherit"
@@ -177,7 +179,7 @@ function GithubIssuePreview({
     day: 'numeric',
   });
   return (
-    <div className="hover-document w-[400px] sm:max-w-[400px] p-3">
+    <div className="hover-document article w-[400px] sm:max-w-[400px] p-3">
       <div className="text-xs font-light">
         {org}/{repo}
       </div>

--- a/packages/myst-to-react/src/links/rrid.tsx
+++ b/packages/myst-to-react/src/links/rrid.tsx
@@ -11,12 +11,16 @@ function RRIDChild({ rrid }: { rrid: string }) {
   const { data, error } = useSWR(`https://scicrunch.org/resolver/${rrid}.json`, fetcher);
   if (!data && !error) {
     return (
-      <div className="hover-document w-[500px] sm:max-w-[500px] animate-pulse">Loading...</div>
+      <div className="hover-document article w-[500px] sm:max-w-[500px] animate-pulse">
+        Loading...
+      </div>
     );
   }
   const hit = data?.hits?.hits?.[0];
   if (error || !hit) {
-    return <div className="hover-document w-[500px] sm:max-w-[500px]">Error loading {rrid}.</div>;
+    return (
+      <div className="hover-document article w-[500px] sm:max-w-[500px]">Error loading {rrid}.</div>
+    );
   }
   const {
     name: title,
@@ -30,7 +34,7 @@ function RRIDChild({ rrid }: { rrid: string }) {
   const types = (categories?.map(({ name }: { name: string }) => name) as string[]) ?? [];
   const tags = (keywords?.map(({ keyword }: { keyword: string }) => keyword) as string[]) ?? [];
   return (
-    <div className="hover-document w-[500px] sm:max-w-[500px] p-3">
+    <div className="hover-document article w-[500px] sm:max-w-[500px] p-3">
       <p className="text-sm font-light">RRID: {category}</p>
       <div className="mb-4 text-xl font-bold">
         {title} <code>{curie}</code>

--- a/styles/hover.css
+++ b/styles/hover.css
@@ -33,7 +33,7 @@
 }
 
 .hover-document {
-  @apply text-sm bg-white border rounded shadow-xl dark:bg-slate-800 border-gray-50 article;
+  @apply text-sm bg-white border rounded shadow-xl dark:bg-slate-800 border-gray-50;
 }
 
 .hover-link {


### PR DESCRIPTION
This gets around the following error:

![image](https://github.com/executablebooks/myst-theme/assets/913249/98968f8f-1e69-49f2-873a-a95604289ab1)
