### PR TITLE
🪝move launch binder logic to reusable hook

### DIFF
--- a/.changeset/warm-mice-repair.md
+++ b/.changeset/warm-mice-repair.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/jupyter': patch
+---
+
+Separate out launch binder logic into a reusable hook

--- a/packages/jupyter/src/index.tsx
+++ b/packages/jupyter/src/index.tsx
@@ -14,5 +14,7 @@ export * from './ConnectionStatusTray.js';
 export * from './providers.js';
 export * from './execute/index.js';
 export * from './controls/index.js';
+export * from './utils.js';
+export { useLaunchBinder } from './hooks.js';
 
 export default OUTPUT_RENDERERS;

--- a/packages/jupyter/src/providers.tsx
+++ b/packages/jupyter/src/providers.tsx
@@ -8,7 +8,7 @@ import type { RepoProviderSpec } from 'thebe-core';
 
 function makeThebeOptions(
   siteManifest: SiteManifest | undefined,
-  optionsOverrideFn = (opts?: ExtendedCoreOptions) => opts,
+  optionsOverrideFn = (opts: ExtendedCoreOptions) => opts,
 ): {
   options?: ExtendedCoreOptions;
   githubBadgeUrl?: string;
@@ -27,7 +27,8 @@ function makeThebeOptions(
     binderBadgeUrl,
   );
 
-  const options = optionsOverrideFn(thebeFrontmatter ? optionsFromFrontmatter : undefined);
+  let options = optionsFromFrontmatter;
+  if (options) options = optionsOverrideFn(options);
 
   return {
     options,
@@ -51,7 +52,7 @@ export function ConfiguredThebeServerProvider({
   children,
 }: React.PropsWithChildren<{
   siteManifest?: SiteManifest;
-  optionOverrideFn?: (opts?: ExtendedCoreOptions) => ExtendedCoreOptions;
+  optionOverrideFn?: (opts: ExtendedCoreOptions) => ExtendedCoreOptions;
   customRepoProviders?: RepoProviderSpec[];
 }>) {
   const thebe = React.useMemo(


### PR DESCRIPTION
This enables building of components with different UI/UX needs whilst still reusing most of the underlying logic for the "Launch Binder" button.