### PR TITLE
🧱 Respect `visibility: remove` on blocks

### DIFF
--- a/.changeset/clean-ears-allow.md
+++ b/.changeset/clean-ears-allow.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': patch
+---
+
+Respect visibility: remove on blocks

--- a/.changeset/little-trains-beam.md
+++ b/.changeset/little-trains-beam.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/common': patch
+---
+
+Move logo and logo_dark to options.

--- a/.changeset/stupid-socks-report.md
+++ b/.changeset/stupid-socks-report.md
@@ -1,0 +1,7 @@
+---
+'@myst-theme/article': patch
+'@myst-theme/site': patch
+'@myst-theme/book': patch
+---
+
+Get design fields from options

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -97,8 +97,26 @@ export function updateSiteManifestStaticLinksInplace(
     action.url = updateUrl(action.url);
   });
   // TODO: this needs to be based on the template.yml in the future
-  if (data.logo) data.logo = updateUrl(data.logo);
-  if (data.logo_dark) data.logo_dark = updateUrl(data.logo_dark);
+  // We have moved logo/logo_dark to options in v1.1.28
+  data.options ??= {};
+  if (data.logo) {
+    data.options.logo = data.logo;
+    delete data.logo;
+  }
+  if (data.logo_dark) {
+    data.options.logo_dark = data.logo_dark;
+    delete data.logo_dark;
+  }
+  if (data.logoText) {
+    data.options.logo_text = data.logoText;
+    delete data.logoText;
+  }
+  if (data.logo_text) {
+    data.options.logo_text = data.logo_text;
+    delete data.logo_text;
+  }
+  if (data.options.logo) data.options.logo = updateUrl(data.options.logo);
+  if (data.options.logo_dark) data.options.logo_dark = updateUrl(data.options.logo_dark);
   // Update the thumbnails to point at the CDN
   data.projects?.forEach((project) => {
     if (project.banner) project.banner = updateUrl(project.banner);

--- a/packages/site/src/components/ContentBlocks.tsx
+++ b/packages/site/src/components/ContentBlocks.tsx
@@ -78,7 +78,7 @@ export function ContentBlocks({
   const blocks = mdast.children as GenericParent[];
   return (
     <>
-      {blocks.map((node) => (
+      {blocks.filter((node) => node.visibility !== 'remove').map((node) => (
         <Block key={node.key} id={node.key} pageKind={pageKind} node={node} className={className} />
       ))}
     </>

--- a/packages/site/src/components/ContentBlocks.tsx
+++ b/packages/site/src/components/ContentBlocks.tsx
@@ -78,9 +78,17 @@ export function ContentBlocks({
   const blocks = mdast.children as GenericParent[];
   return (
     <>
-      {blocks.filter((node) => node.visibility !== 'remove').map((node) => (
-        <Block key={node.key} id={node.key} pageKind={pageKind} node={node} className={className} />
-      ))}
+      {blocks
+        .filter((node) => node.visibility !== 'remove')
+        .map((node) => (
+          <Block
+            key={node.key}
+            id={node.key}
+            pageKind={pageKind}
+            node={node}
+            className={className}
+          />
+        ))}
     </>
   );
 }

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -244,8 +244,8 @@ function HomeLink({
 export function TopNav() {
   const [open, setOpen] = useNavOpen();
   const config = useSiteManifest();
-  const { logo, logo_dark, logo_text, logoText, actions, title, nav } =
-    config ?? ({} as SiteManifest);
+  const { title, nav, actions } = config ?? {};
+  const { logo, logo_dark, logo_text } = config?.options ?? {};
   return (
     <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 fixed w-screen top-0 z-30 h-[60px]">
       <nav className="flex items-center justify-between flex-wrap max-w-[1440px] mx-auto">
@@ -261,12 +261,7 @@ export function TopNav() {
               <span className="sr-only">Open Menu</span>
             </button>
           </div>
-          <HomeLink
-            name={title}
-            logo={logo}
-            logoDark={logo_dark}
-            logoText={logo_text || logoText}
-          />
+          <HomeLink name={title} logo={logo} logoDark={logo_dark} logoText={logo_text} />
         </div>
         <div className="flex items-center flex-grow w-auto">
           <NavItems nav={nav} />

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -35,7 +35,7 @@ export const ArticlePage = React.memo(function ({
 }) {
   const canCompute = useCanCompute();
 
-  const { hide_title_block, hide_footer_links } = (article.frontmatter as any)?.design ?? {};
+  const { hide_title_block, hide_footer_links } = (article.frontmatter as any)?.options ?? {};
 
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];

--- a/themes/article/app/routes/$.tsx
+++ b/themes/article/app/routes/$.tsx
@@ -248,7 +248,7 @@ export function ArticlePage({ article }: { article: PageLoader }) {
 export default function Page() {
   // const { container, outline } = useOutlineHeight();
   const article = useLoaderData<PageLoader>() as PageLoader;
-  const { hide_outline } = (article.frontmatter as any)?.design ?? {};
+  const { hide_outline } = (article.frontmatter as any)?.options ?? {};
 
   return (
     <ArticlePageAndNavigation>

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -96,9 +96,9 @@ export default function Page() {
   const { container, outline } = useOutlineHeight();
   const top = useThemeTop();
   const article = useLoaderData<PageLoader>() as PageLoader;
-  const pageDesign: BookThemeTemplateOptions = (article.frontmatter as any)?.design ?? {};
+  const pageDesign: BookThemeTemplateOptions = (article.frontmatter as any)?.options ?? {};
   const siteDesign: BookThemeTemplateOptions =
-    (useSiteManifest() as SiteManifest & BookThemeTemplateOptions) ?? {};
+    (useSiteManifest() as SiteManifest & BookThemeTemplateOptions)?.options ?? {};
   const { hide_toc, hide_outline, hide_footer_links } = { ...siteDesign, ...pageDesign };
   return (
     <ArticlePageAndNavigation hide_toc={hide_toc} projectSlug={article.project}>


### PR DESCRIPTION
`block` nodes have a "visibility" attribute that is getting more use with this PR: https://github.com/executablebooks/mystmd/pull/736  - parts defined in frontmatter are moved to hidden content blocks. This PR respects that flag by simply not rendering the block content.