### PR TITLE
🔗 Link copy should not include zero-width space

### DIFF
--- a/.changeset/plenty-bears-applaud.md
+++ b/.changeset/plenty-bears-applaud.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Improve link URL copying

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -81,7 +81,22 @@ type BasicNodeRenderers = {
 
 const BASIC_RENDERERS: BasicNodeRenderers = {
   text({ node }) {
-    return <>{node.value}</>;
+    // Change zero-width space into `<wbr>` which is better for copying
+    // These are used in links, and potentially other long words
+    if (!node.value?.includes('​')) {
+      return <>{node.value}</>;
+    }
+    const text = node.value.split('​');
+    return (
+      <>
+        {text.map((v, i) => (
+          <>
+            {v}
+            {i < text.length - 1 && <wbr />}
+          </>
+        ))}
+      </>
+    );
   },
   span({ node }) {
     // style={node.style}

--- a/packages/myst-to-react/src/links/index.tsx
+++ b/packages/myst-to-react/src/links/index.tsx
@@ -54,6 +54,28 @@ function InternalLink({ url, children }: { url: string; children: React.ReactNod
   );
 }
 
+/** This changes zero-width space into `<wbr>` which is better for copying */
+const FormattedLinkText: NodeRenderer<TransformedLink> = ({ node }) => {
+  if (
+    node.children?.length !== 1 ||
+    node.children[0].type !== 'text' ||
+    !node.children[0].value.includes('​')
+  ) {
+    return <MyST ast={node.children} />;
+  }
+  const text = node.children[0].value.split('​');
+  return (
+    <>
+      {text.map((v, i) => (
+        <>
+          {v}
+          {i < text.length - 1 && <wbr />}
+        </>
+      ))}
+    </>
+  );
+};
+
 export const link: NodeRenderer<TransformedLink> = ({ node }) => {
   const internal = node.internal ?? false;
   const protocol = node.protocol;
@@ -62,7 +84,7 @@ export const link: NodeRenderer<TransformedLink> = ({ node }) => {
     case 'wiki':
       return (
         <WikiLink url={node.url} page={node.data?.page as string} wiki={node.data?.wiki as string}>
-          <MyST ast={node.children} />
+          <FormattedLinkText node={node} />
         </WikiLink>
       );
     case 'github':
@@ -78,7 +100,7 @@ export const link: NodeRenderer<TransformedLink> = ({ node }) => {
           to={node.data?.to as number | undefined}
           issue_number={node.data?.issue_number as number | undefined}
         >
-          <MyST ast={node.children} />
+          <FormattedLinkText node={node} />
         </GithubLink>
       );
     case 'rrid':
@@ -87,13 +109,13 @@ export const link: NodeRenderer<TransformedLink> = ({ node }) => {
       if (internal) {
         return (
           <InternalLink url={node.url}>
-            <MyST ast={node.children} />
+            <FormattedLinkText node={node} />
           </InternalLink>
         );
       }
       return (
         <a target="_blank" href={node.url} rel="noreferrer">
-          <MyST ast={node.children} />
+          <FormattedLinkText node={node} />
         </a>
       );
   }

--- a/packages/myst-to-react/src/links/index.tsx
+++ b/packages/myst-to-react/src/links/index.tsx
@@ -54,28 +54,6 @@ function InternalLink({ url, children }: { url: string; children: React.ReactNod
   );
 }
 
-/** This changes zero-width space into `<wbr>` which is better for copying */
-const FormattedLinkText: NodeRenderer<TransformedLink> = ({ node }) => {
-  if (
-    node.children?.length !== 1 ||
-    node.children[0].type !== 'text' ||
-    !node.children[0].value.includes('​')
-  ) {
-    return <MyST ast={node.children} />;
-  }
-  const text = node.children[0].value.split('​');
-  return (
-    <>
-      {text.map((v, i) => (
-        <>
-          {v}
-          {i < text.length - 1 && <wbr />}
-        </>
-      ))}
-    </>
-  );
-};
-
 export const link: NodeRenderer<TransformedLink> = ({ node }) => {
   const internal = node.internal ?? false;
   const protocol = node.protocol;
@@ -84,7 +62,7 @@ export const link: NodeRenderer<TransformedLink> = ({ node }) => {
     case 'wiki':
       return (
         <WikiLink url={node.url} page={node.data?.page as string} wiki={node.data?.wiki as string}>
-          <FormattedLinkText node={node} />
+          <MyST ast={node.children} />
         </WikiLink>
       );
     case 'github':
@@ -100,7 +78,7 @@ export const link: NodeRenderer<TransformedLink> = ({ node }) => {
           to={node.data?.to as number | undefined}
           issue_number={node.data?.issue_number as number | undefined}
         >
-          <FormattedLinkText node={node} />
+          <MyST ast={node.children} />
         </GithubLink>
       );
     case 'rrid':
@@ -109,13 +87,13 @@ export const link: NodeRenderer<TransformedLink> = ({ node }) => {
       if (internal) {
         return (
           <InternalLink url={node.url}>
-            <FormattedLinkText node={node} />
+            <MyST ast={node.children} />
           </InternalLink>
         );
       }
       return (
         <a target="_blank" href={node.url} rel="noreferrer">
-          <FormattedLinkText node={node} />
+          <MyST ast={node.children} />
         </a>
       );
   }


### PR DESCRIPTION
The zero-width space is used for formatting.
This is now turned into a `<wbr>` tag, which doesn't copy to clipboard.