### PR TITLE
👩‍🎨 Nest design under options

### DIFF
--- a/.changeset/stupid-socks-report.md
+++ b/.changeset/stupid-socks-report.md
@@ -1,0 +1,7 @@
+---
+'@myst-theme/article': patch
+'@myst-theme/site': patch
+'@myst-theme/book': patch
+---
+
+Get design fields from options

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -34,7 +34,8 @@ export const ArticlePage = React.memo(function ({
   hideKeywords?: boolean;
 }) {
   const canCompute = useCanCompute(article);
-  const { hide_title_block, hide_footer_links } = (article.frontmatter as any)?.design ?? {};
+  const { hide_title_block, hide_footer_links } =
+    (article.frontmatter as any)?.options?.design ?? {};
 
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -34,8 +34,7 @@ export const ArticlePage = React.memo(function ({
   hideKeywords?: boolean;
 }) {
   const canCompute = useCanCompute(article);
-  const { hide_title_block, hide_footer_links } =
-    (article.frontmatter as any)?.options?.design ?? {};
+  const { hide_title_block, hide_footer_links } = (article.frontmatter as any)?.options ?? {};
 
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];

--- a/themes/article/app/routes/$.tsx
+++ b/themes/article/app/routes/$.tsx
@@ -250,7 +250,7 @@ export function ArticlePage({ article }: { article: PageLoader }) {
 export default function Page() {
   // const { container, outline } = useOutlineHeight();
   const article = useLoaderData<PageLoader>() as PageLoader;
-  const { hide_outline } = (article.frontmatter as any)?.design ?? {};
+  const { hide_outline } = (article.frontmatter as any)?.options?.design ?? {};
 
   return (
     <ArticlePageAndNavigation>

--- a/themes/article/app/routes/$.tsx
+++ b/themes/article/app/routes/$.tsx
@@ -250,7 +250,7 @@ export function ArticlePage({ article }: { article: PageLoader }) {
 export default function Page() {
   // const { container, outline } = useOutlineHeight();
   const article = useLoaderData<PageLoader>() as PageLoader;
-  const { hide_outline } = (article.frontmatter as any)?.options?.design ?? {};
+  const { hide_outline } = (article.frontmatter as any)?.options ?? {};
 
   return (
     <ArticlePageAndNavigation>

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -96,9 +96,9 @@ export default function Page() {
   const { container, outline } = useOutlineHeight();
   const top = useThemeTop();
   const article = useLoaderData<PageLoader>() as PageLoader;
-  const pageDesign: BookThemeTemplateOptions = (article.frontmatter as any)?.options?.design ?? {};
+  const pageDesign: BookThemeTemplateOptions = (article.frontmatter as any)?.options ?? {};
   const siteDesign: BookThemeTemplateOptions =
-    (useSiteManifest() as SiteManifest & BookThemeTemplateOptions)?.options?.design ?? {};
+    (useSiteManifest() as SiteManifest & BookThemeTemplateOptions)?.options ?? {};
   const { hide_toc, hide_outline, hide_footer_links } = { ...siteDesign, ...pageDesign };
   return (
     <ArticlePageAndNavigation hide_toc={hide_toc} projectSlug={article.project}>

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -96,9 +96,9 @@ export default function Page() {
   const { container, outline } = useOutlineHeight();
   const top = useThemeTop();
   const article = useLoaderData<PageLoader>() as PageLoader;
-  const pageDesign: BookThemeTemplateOptions = (article.frontmatter as any)?.design ?? {};
+  const pageDesign: BookThemeTemplateOptions = (article.frontmatter as any)?.options?.design ?? {};
   const siteDesign: BookThemeTemplateOptions =
-    (useSiteManifest() as SiteManifest & BookThemeTemplateOptions) ?? {};
+    (useSiteManifest() as SiteManifest & BookThemeTemplateOptions)?.options?.design ?? {};
   const { hide_toc, hide_outline, hide_footer_links } = { ...siteDesign, ...pageDesign };
   return (
     <ArticlePageAndNavigation hide_toc={hide_toc} projectSlug={article.project}>


### PR DESCRIPTION
I'm not sure how `design` is coming into article frontmatter, so I'm not sure if these changes are correct. However, with the introduction of `siteConfig.options`, `siteConfig.design` is now moved to `siteConfig.options.design`...