### PR TITLE
📒 Allow executable code/output to be inside a figure

### DIFF
--- a/.changeset/nasty-carrots-attack.md
+++ b/.changeset/nasty-carrots-attack.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/jupyter': patch
+'@myst-theme/site': patch
+---
+
+Allow executable code/output to be inside a figure

--- a/packages/jupyter/src/execute/index.ts
+++ b/packages/jupyter/src/execute/index.ts
@@ -4,3 +4,4 @@ export * from './provider.js';
 export * from './selectors.js';
 export * from './types.js';
 export * from './busy.js';
+export * from './utils.js';

--- a/packages/site/src/components/ContentBlocks.tsx
+++ b/packages/site/src/components/ContentBlocks.tsx
@@ -3,6 +3,7 @@ import { SourceFileKind } from 'myst-spec-ext';
 import type { GenericParent } from 'myst-common';
 import classNames from 'classnames';
 import {
+  executableNodesFromBlock,
   NotebookClearCell,
   NotebookRunCell,
   NotebookRunCellSpinnerOnly,
@@ -10,14 +11,7 @@ import {
 import { useGridSystemProvider } from '@myst-theme/providers';
 
 function isACodeCell(node: GenericParent) {
-  return (
-    node &&
-    node.type === 'block' &&
-    node.children &&
-    node.children?.length === 2 &&
-    node.children[0].type === 'code' &&
-    node.children[1].type === 'output'
-  );
+  return !!executableNodesFromBlock(node);
 }
 
 function Block({


### PR DESCRIPTION
This PR consolidates the logic for finding `code`/`output` cells in a `block`. It also reduces the strictness of this logic:

Previously the only block structure that resolved to executable code/output was:
```
block
 |- code
 |- output
```

Now, that structure is still allowed along with:
```
block
 |- figure
     |- code
     |- output
     |- caption
```
as added in https://github.com/executablebooks/mystmd/pull/760