### PR TITLE
🕺split out compute options provider and add feature flags

### DIFF
--- a/.changeset/yellow-flies-attack.md
+++ b/.changeset/yellow-flies-attack.md
@@ -1,0 +1,11 @@
+---
+'@myst-theme/jupyter': patch
+'@myst-theme/article': patch
+'@myst-theme/site': patch
+'@myst-theme/book': patch
+---
+
+- Split up ConfiguredThebeServer provider moving ComputeOptions out allowing it to be higher up in the render tree.
+- `thebe-lite` bundle is now loaded when lite is enabled in frontmatter.
+- Added feature flags to enable different ui compute features.
+- fixed busy state on notebook error.

--- a/packages/jupyter/src/ConnectionStatusTray.tsx
+++ b/packages/jupyter/src/ConnectionStatusTray.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useThebeServer } from 'thebe-react';
-import { useThebeOptions } from './providers.js';
+import { useComputeOptions } from './providers.js';
 import type { ThebeEventData, ThebeEventType } from 'thebe-core';
 import { selectAreExecutionScopesBuilding, useExecutionScope } from './execute/index.js';
 
 export function ConnectionStatusTray({ waitForSessions }: { waitForSessions?: boolean }) {
-  const thebe = useThebeOptions();
+  // TODO: return naming change
+  const thebe = useComputeOptions();
   const { connecting, ready: serverReady, error: serverError, events } = useThebeServer();
   const { slug, ready: scopeReady, state } = useExecutionScope();
   const [show, setShow] = useState(false);

--- a/packages/jupyter/src/ErrorTray.tsx
+++ b/packages/jupyter/src/ErrorTray.tsx
@@ -8,7 +8,7 @@ function ErrorDecoration({ children, idx }: React.PropsWithChildren<{ idx?: numb
   return (
     <div className="relative py-3 mx-2 my-8 border rounded">
       <div className="absolute z-10 flex items-center bg-white -top-3 -left-2">
-        {idx && <div className="ml-1 text-sm text-gray-500">cell #: {idx}</div>}
+        {idx && <div className="ml-1 text-sm text-gray-500">cell #: {idx + 1}</div>}
       </div>
       <div className="mx-3">{children}</div>
     </div>
@@ -54,7 +54,7 @@ export function ErrorTray({ pageSlug, index }: { pageSlug: string; index?: strin
   if (!items || items.length === 0) return null;
   if (index && index) return null;
   return (
-    <div className="relative px-4 pt-3 mt-8 text-sm text-red-600 border border-red-400 rounded border-1">
+    <div className="relative px-4 pt-3 my-8 text-sm text-red-600 border border-red-400 rounded border-1">
       {items.map(({ notebookSlug, errors }) => {
         return (
           <div>

--- a/packages/jupyter/src/decoration.tsx
+++ b/packages/jupyter/src/decoration.tsx
@@ -9,6 +9,7 @@ import {
 } from './controls/ArticleCellControls.js';
 import { JupyterIcon } from '@scienceicons/react/24/solid';
 import { useLinkProvider, useBaseurl, withBaseurl, useThemeTop } from '@myst-theme/providers';
+import { useComputeOptions } from './providers.js';
 
 const PlaceholderContext = React.createContext<{ placeholder?: GenericNode }>({});
 
@@ -38,11 +39,13 @@ export function OutputDecoration({
   title?: string;
   url?: string;
 }) {
-  const { canCompute, kind } = useCellExecution(outputId);
+  const { kind } = useCellExecution(outputId);
+  const compute = useComputeOptions();
   const Link = useLinkProvider();
   const top = useThemeTop();
   const baseurl = useBaseurl();
-  const showComputeControls = canCompute && kind === SourceFileKind.Article;
+  const showComputeControls =
+    compute?.enabled && compute?.features.figureCompute && kind === SourceFileKind.Article;
 
   if (showComputeControls) {
     return (

--- a/packages/jupyter/src/execute/hooks.ts
+++ b/packages/jupyter/src/execute/hooks.ts
@@ -62,7 +62,11 @@ export function useExecutionScope({
         Object.entries(state.pages[slug].scopes).map(async ([, { notebook }]) => {
           const execReturns = await notebook.executeAll(true);
           const errs = findErrors(execReturns);
-          if (errs != null) console.error('errors', errs);
+          if (errs != null) {
+            console.error('errors', errs);
+            busy.setError(slug, notebook.id, errs);
+            busy.clearNotebook(slug, notebook.id, 'execute');
+          }
         }),
       );
       config?.events.off('status' as any, handler);

--- a/packages/jupyter/src/execute/provider.tsx
+++ b/packages/jupyter/src/execute/provider.tsx
@@ -12,8 +12,6 @@ import {
   selectSessionsToStart,
 } from './selectors.js';
 import { MdastFetcher, NotebookBuilder, ServerMonitor, SessionStarter } from './leaf.js';
-import { useCanCompute } from '../providers.js';
-import type { Thebe } from 'myst-frontmatter';
 import type { GenericParent } from 'myst-common';
 
 export interface ExecuteScopeType {

--- a/packages/jupyter/src/utils.ts
+++ b/packages/jupyter/src/utils.ts
@@ -1,3 +1,4 @@
+import type { ManifestProject } from '@myst-theme/providers';
 import type { Thebe, JupyterServerOptions, BinderHubOptions } from 'myst-frontmatter';
 import type { CoreOptions, WellKnownRepoProvider } from 'thebe-core';
 
@@ -177,4 +178,31 @@ export function thebeFrontmatterToOptions(
   }
   // else if (fm === true || server === true || !server) => do nothing - just return / fall though for defaults
   return thebeOptions;
+}
+
+export function makeThebeOptions(
+  project: ManifestProject,
+  optionsOverrideFn = (opts?: ExtendedCoreOptions) => opts,
+): {
+  options?: ExtendedCoreOptions;
+  githubBadgeUrl?: string;
+  binderBadgeUrl?: string;
+} {
+  if (!project) return {};
+  const thebeFrontmatter = project?.thebe;
+  const githubBadgeUrl = project?.github;
+  const binderBadgeUrl = project?.binder;
+  const optionsFromFrontmatter = thebeFrontmatterToOptions(
+    thebeFrontmatter,
+    githubBadgeUrl,
+    binderBadgeUrl,
+  );
+
+  const options = optionsOverrideFn(optionsFromFrontmatter);
+
+  return {
+    options,
+    githubBadgeUrl,
+    binderBadgeUrl,
+  };
 }

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -17,8 +17,8 @@ import {
   BusyScopeProvider,
   NotebookToolbar,
   ConnectionStatusTray,
-  useCanCompute,
   ErrorTray,
+  useComputeOptions,
 } from '@myst-theme/jupyter';
 import { FrontmatterBlock } from '@myst-theme/frontmatter';
 import { extractKnownParts } from '../utils.js';
@@ -32,7 +32,7 @@ export const ArticlePage = React.memo(function ({
   hide_all_footer_links?: boolean;
   hideKeywords?: boolean;
 }) {
-  const canCompute = useCanCompute();
+  const compute = useComputeOptions();
 
   const { hide_title_block, hide_footer_links } = (article.frontmatter as any)?.options ?? {};
 
@@ -46,7 +46,7 @@ export const ArticlePage = React.memo(function ({
       frontmatter={article.frontmatter}
     >
       <BusyScopeProvider>
-        <ExecuteScopeProvider enable={canCompute} contents={article}>
+        <ExecuteScopeProvider enable={compute?.enabled ?? false} contents={article}>
           {!hide_title_block && (
             <FrontmatterBlock
               kind={article.kind}
@@ -54,7 +54,9 @@ export const ArticlePage = React.memo(function ({
               className="pt-5 mb-8"
             />
           )}
-          {canCompute && article.kind === SourceFileKind.Notebook && <NotebookToolbar showLaunch />}
+          {compute?.enabled &&
+            compute.features.notebookCompute &&
+            article.kind === SourceFileKind.Notebook && <NotebookToolbar showLaunch />}
           <ErrorTray pageSlug={article.slug} />
           <div id="skip-to-article" />
           <FrontmatterParts parts={parts} keywords={keywords} hideKeywords={hideKeywords} />

--- a/themes/article/app/root.tsx
+++ b/themes/article/app/root.tsx
@@ -58,6 +58,7 @@ export default function AppWithReload() {
     <Document
       theme={theme}
       config={config}
+      features={{ notebookCompute: false, figureCompute: true, launchBinder: true }}
       scripts={MODE === 'static' ? undefined : <ContentReload port={CONTENT_CDN_PORT} />}
       staticBuild={MODE === 'static'}
       baseurl={BASE_URL}

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -58,6 +58,7 @@ export default function AppWithReload() {
     <Document
       theme={theme}
       config={config}
+      features={{ notebookCompute: true, figureCompute: true, launchBinder: true }}
       scripts={MODE === 'static' ? undefined : <ContentReload port={CONTENT_CDN_PORT} />}
       staticBuild={MODE === 'static'}
       baseurl={BASE_URL}


### PR DESCRIPTION
Bundling the ThebeOptions provider in beside the ThebeServer really hurts flexiblity. The ThebeOptions could be much further up the render tree and early analysis of the thebe option can be used to setup the site, e.g. like knowing whether to load thebe lite or not.

Providers are split out here and we also add flags to enable different parts of the compute ui separately.