### PR TITLE
📇 swaping binder for jupyter in ui

### DIFF
--- a/packages/jupyter/src/BinderBadge.tsx
+++ b/packages/jupyter/src/BinderBadge.tsx
@@ -63,7 +63,7 @@ export function BinderBadge({ binder }: { binder?: string }) {
     <div className="inline-block m-1 opacity-80 hover:opacity-100">
       <a
         href={binder}
-        title={`Launch Binder Session: ${binder}`}
+        title={`Launch Jupyter Session: ${binder}`}
         target="_blank"
         rel="noopener noreferrer"
         className="text-inherit hover:text-inherit"

--- a/packages/jupyter/src/ConnectionStatusTray.tsx
+++ b/packages/jupyter/src/ConnectionStatusTray.tsx
@@ -39,7 +39,7 @@ export function ConnectionStatusTray({ waitForSessions }: { waitForSessions?: bo
   }, [options, busy, ready, error]);
 
   const host = options?.thebe?.useBinder
-    ? 'Binder'
+    ? 'Jupyter'
     : options?.thebe?.useJupyterLite
     ? 'JupyterLite'
     : 'Local Server';

--- a/packages/jupyter/src/controls/Buttons.tsx
+++ b/packages/jupyter/src/controls/Buttons.tsx
@@ -88,20 +88,20 @@ export function LaunchBinder({ type, location }: { type: 'link' | 'button'; loca
       >
         <div className="flex items-center h-full">
           {icon}
-          <span>Open in Binder</span>
+          <span>Open in Jupyter</span>
         </div>
       </a>
     );
   }
 
-  let label = 'Launch Binder';
+  let label = 'Launch Jupyter';
   let title = 'Click to start a new compute session';
   if (error) {
     label = 'Launch Error';
     title = error;
   } else if (connecting) {
     label = 'Launching...';
-    title = 'Connecting to binder, please wait';
+    title = 'Starting a jupyter server, please wait';
   }
 
   return (


### PR DESCRIPTION
Launch Binder doesn't click with many readers, where Launch Jupyter does.