### PR TITLE
🐥 Support twitter as site option

### DIFF
--- a/.changeset/healthy-dragons-report.md
+++ b/.changeset/healthy-dragons-report.md
@@ -1,0 +1,7 @@
+---
+'@myst-theme/common': patch
+'@myst-theme/article': patch
+'@myst-theme/book': patch
+---
+
+Support twitter as site option

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -115,6 +115,10 @@ export function updateSiteManifestStaticLinksInplace(
     data.options.logo_text = (data as any).logo_text;
     delete (data as any).logo_text;
   }
+  if ((data as any).twitter) {
+    data.options.twitter = (data as any).twitter;
+    delete (data as any).twitter;
+  }
   if ((data as any).analytics_google) {
     data.options.analytics_google = (data as any).analytics_google;
     delete (data as any).analytics_google;

--- a/themes/article/app/root.tsx
+++ b/themes/article/app/root.tsx
@@ -17,7 +17,7 @@ export { AppCatchBoundary as CatchBoundary } from '@myst-theme/site';
 export const meta: MetaFunction = ({ data }) => {
   return getMetaTagsForSite({
     title: data?.config?.title,
-    twitter: data?.config?.twitter,
+    twitter: data?.config?.options?.twitter,
   });
 };
 

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -17,7 +17,7 @@ export { AppCatchBoundary as CatchBoundary } from '@myst-theme/site';
 export const meta: MetaFunction = ({ data }) => {
   return getMetaTagsForSite({
     title: data?.config?.title,
-    twitter: data?.config?.twitter,
+    twitter: data?.config?.options?.twitter,
   });
 };
 


### PR DESCRIPTION
`twitter` is a site option for book/article theme in the `template.yml`. However, the themes were not picking this up from the correct place. Now, for meta tags, twitter comes from options.