### PR TITLE
feat: support the align attribute in tablecell

### DIFF
--- a/.changeset/forty-dogs-march.md
+++ b/.changeset/forty-dogs-march.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': minor
+---
+
+Support align in table cells

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -282,14 +282,19 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
       rowSpan: ifGreaterThanOne(node.rowspan),
       colSpan: ifGreaterThanOne(node.colspan),
     };
+    const align = {
+      'text-left': node.align === 'left',
+      'text-right': node.align === 'right',
+      'text-center': node.align === 'center',
+    };
     if (node.header)
       return (
-        <th className={node.class} style={node.style} align={node.align} {...attrs}>
+        <th className={classNames(node.class, align)} style={node.style} {...attrs}>
           <MyST ast={node.children} />
         </th>
       );
     return (
-      <td className={node.class} style={node.style} align={node.align} {...attrs}>
+      <td className={classNames(node.class, align)} style={node.style} {...attrs}>
         <MyST ast={node.children} />
       </td>
     );

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -284,12 +284,12 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
     };
     if (node.header)
       return (
-        <th className={node.class} style={node.style} {...attrs}>
+        <th className={node.class} style={node.style} align={node.align} {...attrs}>
           <MyST ast={node.children} />
         </th>
       );
     return (
-      <td className={node.class} style={node.style} {...attrs}>
+      <td className={node.class} style={node.style} align={node.align} {...attrs}>
         <MyST ast={node.children} />
       </td>
     );


### PR DESCRIPTION
Hey @fwkoch, I pinged you for review of this because I need to be better at pinging "not rowan"! Let me know if I should instead ask Rowan for review on this!

This PR simply passes through the `align` attribute of `TableCell` to the underlying `td`/`th` element.

As a PR in myst-theme, this doesn't address the problem of alignment in HTML / LaTeX exports.