### PR TITLE
🐛 Videos do not show if the URL contains queries

### DIFF
--- a/.changeset/smooth-yaks-talk.md
+++ b/.changeset/smooth-yaks-talk.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Look to original url to determine if a video

--- a/packages/myst-to-react/src/image.tsx
+++ b/packages/myst-to-react/src/image.tsx
@@ -86,7 +86,7 @@ function Picture({
   height?: string;
   align?: Alignment;
 }) {
-  if (src.endsWith('.mp4')) {
+  if (src.endsWith('.mp4') || urlSource?.endsWith('.mp4')) {
     return <Video width={width} height={height} align={align} src={src} urlSource={urlSource} />;
   }
   const image = (


### PR DESCRIPTION
This fixes when videos work locally, but may not work if the URL is changed by adding a query string.