### PR TITLE
🔧 added official mimetype for svg when filtering output bundles

### DIFF
--- a/packages/jupyter/src/convertImages.ts
+++ b/packages/jupyter/src/convertImages.ts
@@ -34,7 +34,6 @@ export async function fetchAndEncodeOutputImages(
     outputs.map(async (output) => {
       if (!('data' in output)) return output;
 
-      console.log('output', output);
       const imageMimetypes = Object.keys(output.data as MinifiedMimeBundle).filter(
         (mimetype) =>
           mimetype !== 'image/svg' && mimetype !== 'image/svg+xml' && mimetype.startsWith('image/'),

--- a/packages/jupyter/src/convertImages.ts
+++ b/packages/jupyter/src/convertImages.ts
@@ -34,8 +34,10 @@ export async function fetchAndEncodeOutputImages(
     outputs.map(async (output) => {
       if (!('data' in output)) return output;
 
+      console.log('output', output);
       const imageMimetypes = Object.keys(output.data as MinifiedMimeBundle).filter(
-        (mimetype) => mimetype !== 'image/svg' && mimetype.startsWith('image/'),
+        (mimetype) =>
+          mimetype !== 'image/svg' && mimetype !== 'image/svg+xml' && mimetype.startsWith('image/'),
       );
       if (imageMimetypes.length === 0) return output;
       // this is an async fetch, so we need to await the result


### PR DESCRIPTION
This fixes https://github.com/executablebooks/mystmd/issues/916 in local testing

`image/svg-xml` is the correct and offical (IANA) mimetype identifier for SVG images, so we should be filtering based on that. 

`image/svg` is not an official mimetype at all, but I've left it in place - hesistating here in case the original code was covering some edge case that's out there ins the wild.

Happy to remove it though if that's the concensus.