### PR TITLE
interim support for plotly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,6 +2433,22 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/@choojs/findup": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
+      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+      "dependencies": {
+        "commander": "^2.15.1"
+      },
+      "bin": {
+        "findup": "bin/findup.js"
+      }
+    },
+    "node_modules/@choojs/findup/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/@citation-js/cli": {
       "version": "0.6.9",
       "resolved": "https://registry.npmjs.org/@citation-js/cli/-/cli-0.6.9.tgz",
@@ -6689,6 +6705,81 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "peerDependencies": {
+        "mapbox-gl": ">=0.32.1 <2.0.0"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.3.0.tgz",
@@ -6918,6 +7009,117 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@plotly/d3": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.1.tgz",
+      "integrity": "sha512-x49ThEu1FRA00kTso4Jdfyf2byaCPLBGmLjAYQz5OzaPyLUhHesX3/Nfv2OHEhynhdy2UB39DLXq6thYe2L2kg=="
+    },
+    "node_modules/@plotly/d3-sankey": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
+      "dependencies": {
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/@plotly/d3-sankey-circular": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
+      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
+      "dependencies": {
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "node_modules/@plotly/d3-sankey-circular/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/@plotly/d3-sankey-circular/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/@plotly/d3-sankey-circular/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/@plotly/d3-sankey/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/@plotly/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/@plotly/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/@plotly/mapbox-gl": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@plotly/mapbox-gl/-/mapbox-gl-1.13.4.tgz",
+      "integrity": "sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/@plotly/point-cluster": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
+      "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "binary-search-bounds": "^2.0.4",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -12327,6 +12529,61 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
+      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
@@ -14544,6 +14801,11 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -14717,6 +14979,11 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/almost-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
+      "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A=="
+    },
     "node_modules/anser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/anser/-/anser-2.1.1.tgz",
@@ -14845,6 +15112,11 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-bounds": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
+      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ=="
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
@@ -14856,6 +15128,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/array-flatten": {
@@ -14891,6 +15171,24 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/array-normalize": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
+      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
+      "dependencies": {
+        "array-bounds": "^1.0.0"
+      }
+    },
+    "node_modules/array-range": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
+      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA=="
+    },
+    "node_modules/array-rearrange": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
+      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -15606,6 +15904,14 @@
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
       "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -15714,6 +16020,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -15730,6 +16041,16 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA=="
+    },
+    "node_modules/bitmap-sdf": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
+      "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg=="
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -16323,6 +16644,14 @@
         }
       ]
     },
+    "node_modules/canvas-fit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
+      "integrity": "sha512-onIcjRpz69/Hx5bB5HGbYKUF2uC6QT6Gp+pfpGm3A7mPfcluSLV5v4Zu+oflDUwLdUw0rLIBhUbi0v8hM4FJQQ==",
+      "dependencies": {
+        "element-size": "^1.1.1"
+      }
+    },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
@@ -16557,6 +16886,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
+    "node_modules/clamp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+      "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA=="
+    },
     "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
@@ -16754,6 +17088,14 @@
         "node": ">=12.5.0"
       }
     },
+    "node_modules/color-alpha": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
+      "dependencies": {
+        "color-parse": "^1.3.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -16762,10 +17104,57 @@
         "color-name": "1.1.3"
       }
     },
+    "node_modules/color-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
+      "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
+      "dependencies": {
+        "clamp": "^1.0.1"
+      }
+    },
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/color-normalize": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
+      "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
+      "dependencies": {
+        "clamp": "^1.0.1",
+        "color-rgba": "^2.1.1",
+        "dtype": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
+      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "defined": "^1.0.0",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "node_modules/color-rgba": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
+      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
+      "dependencies": {
+        "clamp": "^1.0.1",
+        "color-parse": "^1.3.8",
+        "color-space": "^1.14.6"
+      }
+    },
+    "node_modules/color-space": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
+      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
+      "dependencies": {
+        "hsluv": "^0.0.3",
+        "mumath": "^3.3.4"
+      }
     },
     "node_modules/color-string": {
       "version": "1.9.1",
@@ -16918,7 +17307,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -17188,6 +17576,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/country-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
+      "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA=="
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -17310,6 +17703,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-font": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
+      "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
+      "dependencies": {
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "pick-by-alias": "^1.2.0",
+        "string-split-by": "^1.0.0",
+        "unquote": "^1.1.0"
+      }
+    },
+    "node_modules/css-font-size-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+      "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q=="
+    },
+    "node_modules/css-font-stretch-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+      "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg=="
+    },
+    "node_modules/css-font-style-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+      "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg=="
+    },
+    "node_modules/css-font-weight-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+      "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA=="
+    },
+    "node_modules/css-global-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+      "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ=="
+    },
     "node_modules/css-loader": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.8.1.tgz",
@@ -17400,6 +17834,11 @@
       "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
       "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
     },
+    "node_modules/css-system-font-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+      "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA=="
+    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -17411,6 +17850,11 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -17530,6 +17974,15 @@
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
       "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="
     },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "node_modules/d3": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
@@ -17614,6 +18067,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -17757,6 +18215,42 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
+      "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
+      "dependencies": {
+        "commander": "2",
+        "d3-array": "1",
+        "d3-geo": "^1.12.0",
+        "resolve": "^1.1.10"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg",
+        "geograticule": "bin/geograticule",
+        "geoproject": "bin/geoproject",
+        "geoquantize": "bin/geoquantize",
+        "geostitch": "bin/geostitch"
+      }
+    },
+    "node_modules/d3-geo-projection/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/d3-geo-projection/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-geo-projection/node_modules/d3-geo": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
+      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "dependencies": {
+        "d3-array": "1"
       }
     },
     "node_modules/d3-hierarchy": {
@@ -18377,6 +18871,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
@@ -18590,6 +19092,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-kerning": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
+      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -18880,17 +19387,43 @@
         "node": ">=12"
       }
     },
+    "node_modules/draw-svg-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
+      "integrity": "sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==",
+      "dependencies": {
+        "abs-svg-path": "~0.1.1",
+        "normalize-svg-path": "~0.1.0"
+      }
+    },
+    "node_modules/dtype": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
+      "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/dup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+      "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA=="
+    },
     "node_modules/duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
       }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -18979,6 +19512,19 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.531.tgz",
       "integrity": "sha512-H6gi5E41Rn3/mhKlPaT1aIMg/71hTAqn0gYEllSuw9igNWtvQwu185jiCZoZD29n7Zukgh7GVZ3zGf0XvkhqjQ=="
     },
+    "node_modules/element-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
+      "integrity": "sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ=="
+    },
+    "node_modules/elementary-circuits-directed-graph": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
+      "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
+      "dependencies": {
+        "strongly-connected-components": "^1.0.1"
+      }
+    },
     "node_modules/elkjs": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
@@ -19022,7 +19568,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -19246,6 +19791,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "node_modules/esbuild": {
@@ -20975,7 +21564,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -21161,6 +21749,19 @@
         }
       ]
     },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -21228,6 +21829,34 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
+    "node_modules/falafel": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
+      "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "isarray": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/falafel/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/falafel/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -21265,6 +21894,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fast-isnumeric": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
+      "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
+      "dependencies": {
+        "is-string-blank": "^1.0.1"
       }
     },
     "node_modules/fast-json-parse": {
@@ -21605,6 +22242,14 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/flatten-vertex-data": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
+      "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
+      "dependencies": {
+        "dtype": "^2.0.0"
+      }
+    },
     "node_modules/flow-parser": {
       "version": "0.217.0",
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.217.0.tgz",
@@ -21612,6 +22257,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/font-atlas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
+      "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
+      "dependencies": {
+        "css-font": "^1.0.0"
+      }
+    },
+    "node_modules/font-measure": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
+      "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
+      "dependencies": {
+        "css-font": "^1.2.0"
       }
     },
     "node_modules/for-each": {
@@ -21823,6 +22484,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -21974,6 +22644,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -21981,6 +22656,11 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
+    },
+    "node_modules/get-canvas-context": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
+      "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A=="
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",
@@ -22158,6 +22838,54 @@
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
       "dev": true
     },
+    "node_modules/gl-mat4": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
+      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
+    },
+    "node_modules/gl-text": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.3.1.tgz",
+      "integrity": "sha512-/f5gcEMiZd+UTBJLTl3D+CkCB/0UFGTx3nflH8ZmyWcLkZhsZ1+Xx5YYkw2rgWAzgPeE35xCqBuHSoMKQVsR+w==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.5.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.1.2",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^2.0.0",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/gl-util": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
+      "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
+      "dependencies": {
+        "is-browser": "^2.0.1",
+        "is-firefox": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "number-is-integer": "^1.0.1",
+        "object-assign": "^4.1.0",
+        "pick-by-alias": "^1.2.0",
+        "weak-map": "^1.0.5"
+      }
+    },
     "node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -22264,6 +22992,196 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glsl-inject-defines": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
+      "integrity": "sha512-W49jIhuDtF6w+7wCMcClk27a2hq8znvHtlGnrYkSWEr8tHe9eA2dcnohlcAmxLYBSpSSdzOkRdyPTrx9fw49+A==",
+      "dependencies": {
+        "glsl-token-inject-block": "^1.0.0",
+        "glsl-token-string": "^1.0.1",
+        "glsl-tokenizer": "^2.0.2"
+      }
+    },
+    "node_modules/glsl-resolve": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
+      "integrity": "sha512-xxFNsfnhZTK9NBhzJjSBGX6IOqYpvBHxxmo+4vapiljyGNCY0Bekzn0firQkQrazK59c1hYxMDxYS8MDlhw4gA==",
+      "dependencies": {
+        "resolve": "^0.6.1",
+        "xtend": "^2.1.2"
+      }
+    },
+    "node_modules/glsl-resolve/node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg=="
+    },
+    "node_modules/glsl-resolve/node_modules/xtend": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
+      "integrity": "sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/glsl-token-assignments": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
+      "integrity": "sha512-OwXrxixCyHzzA0U2g4btSNAyB2Dx8XrztY5aVUCjRSh4/D0WoJn8Qdps7Xub3sz6zE73W3szLrmWtQ7QMpeHEQ=="
+    },
+    "node_modules/glsl-token-defines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
+      "integrity": "sha512-Vb5QMVeLjmOwvvOJuPNg3vnRlffscq2/qvIuTpMzuO/7s5kT+63iL6Dfo2FYLWbzuiycWpbC0/KV0biqFwHxaQ==",
+      "dependencies": {
+        "glsl-tokenizer": "^2.0.0"
+      }
+    },
+    "node_modules/glsl-token-depth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
+      "integrity": "sha512-eQnIBLc7vFf8axF9aoi/xW37LSWd2hCQr/3sZui8aBJnksq9C7zMeUYHVJWMhFzXrBU7fgIqni4EhXVW4/krpg=="
+    },
+    "node_modules/glsl-token-descope": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
+      "integrity": "sha512-kS2PTWkvi/YOeicVjXGgX5j7+8N7e56srNDEHDTVZ1dcESmbmpmgrnpjPcjxJjMxh56mSXYoFdZqb90gXkGjQw==",
+      "dependencies": {
+        "glsl-token-assignments": "^2.0.0",
+        "glsl-token-depth": "^1.1.0",
+        "glsl-token-properties": "^1.0.0",
+        "glsl-token-scope": "^1.1.0"
+      }
+    },
+    "node_modules/glsl-token-inject-block": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
+      "integrity": "sha512-q/m+ukdUBuHCOtLhSr0uFb/qYQr4/oKrPSdIK2C4TD+qLaJvqM9wfXIF/OOBjuSA3pUoYHurVRNao6LTVVUPWA=="
+    },
+    "node_modules/glsl-token-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
+      "integrity": "sha512-dSeW1cOIzbuUoYH0y+nxzwK9S9O3wsjttkq5ij9ZGw0OS41BirKJzzH48VLm8qLg+au6b0sINxGC0IrGwtQUcA=="
+    },
+    "node_modules/glsl-token-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
+      "integrity": "sha512-YKyOMk1B/tz9BwYUdfDoHvMIYTGtVv2vbDSLh94PT4+f87z21FVdou1KNKgF+nECBTo0fJ20dpm0B1vZB1Q03A=="
+    },
+    "node_modules/glsl-token-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
+      "integrity": "sha512-1mtQ47Uxd47wrovl+T6RshKGkRRCYWhnELmkEcUAPALWGTFe2XZpH3r45XAwL2B6v+l0KNsCnoaZCSnhzKEksg=="
+    },
+    "node_modules/glsl-token-whitespace-trim": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
+      "integrity": "sha512-ZJtsPut/aDaUdLUNtmBYhaCmhIjpKNg7IgZSfX5wFReMc2vnj8zok+gB/3Quqs0TsBSX/fGnqUUYZDqyuc2xLQ=="
+    },
+    "node_modules/glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "dependencies": {
+        "through2": "^0.6.3"
+      }
+    },
+    "node_modules/glsl-tokenizer/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
+    "node_modules/glsl-tokenizer/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/glsl-tokenizer/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
+    "node_modules/glsl-tokenizer/node_modules/through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/glslify": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
+      "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
+      "dependencies": {
+        "bl": "^2.2.1",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.1.0",
+        "from2": "^2.3.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.5",
+        "resolve": "^1.1.5",
+        "stack-trace": "0.0.9",
+        "static-eval": "^2.0.5",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "glslify": "bin.js"
+      }
+    },
+    "node_modules/glslify-bundle": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
+      "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
+      "dependencies": {
+        "glsl-inject-defines": "^1.0.1",
+        "glsl-token-defines": "^1.0.0",
+        "glsl-token-depth": "^1.1.1",
+        "glsl-token-descope": "^1.0.2",
+        "glsl-token-scope": "^1.1.1",
+        "glsl-token-string": "^1.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2",
+        "murmurhash-js": "^1.0.0",
+        "shallow-copy": "0.0.1"
+      }
+    },
+    "node_modules/glslify-deps": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
+      "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
+      "dependencies": {
+        "@choojs/findup": "^0.2.0",
+        "events": "^3.2.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-tokenizer": "^2.0.0",
+        "graceful-fs": "^4.1.2",
+        "inherits": "^2.0.1",
+        "map-limit": "0.0.1",
+        "resolve": "^1.0.0"
+      }
+    },
+    "node_modules/glslify/node_modules/bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -22316,6 +23234,11 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "node_modules/gunzip-maybe": {
       "version": "1.4.2",
@@ -22404,6 +23327,22 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-hover": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
+      "integrity": "sha512-0G6w7LnlcpyDzpeGUTuT0CEw05+QlMuGVk1IHNAlHrGJITGodjZu3x8BNDUMfKJSZXNB2ZAclqc1bvrd+uUpfg==",
+      "dependencies": {
+        "is-browser": "^2.0.1"
+      }
+    },
+    "node_modules/has-passive-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
+      "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
+      "dependencies": {
+        "is-browser": "^2.0.1"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -22972,6 +23911,11 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "node_modules/hsluv": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
+      "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ=="
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -23247,7 +24191,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -23768,6 +24711,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
+      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
+    },
     "node_modules/is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
@@ -23890,6 +24838,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-firefox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
+      "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -23950,6 +24917,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-iexplorer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
+      "integrity": "sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -24000,6 +24975,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-mobile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-4.0.0.tgz",
+      "integrity": "sha512-mlcHZA84t1qLSuWkt2v0I2l61PYdyQDt4aG1mLIXF5FDMm4+haBCxCPYSr/uwqQNRk1MiTizn0ypEuRAOLRAew=="
     },
     "node_modules/is-nan": {
       "version": "1.3.2",
@@ -24052,6 +25032,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -24074,7 +25062,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24164,6 +25151,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
+    },
     "node_modules/is-subdir": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
@@ -24175,6 +25167,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/is-svg-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
+      "integrity": "sha512-Lj4vePmqpPR1ZnRctHv8ltSh1OrSxHkhUkd7wi+VQdcdP15/KvQFyk7LhNuM7ZW0EVbJz8kZLVmL9quLrfq4Kg=="
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -26939,6 +27936,99 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/jupyterlab-plotly": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/jupyterlab-plotly/-/jupyterlab-plotly-5.18.0.tgz",
+      "integrity": "sha512-2a+WfPqa7dM6I4ZQ5LKAe00lDyyVn1F+wOZdCi0ub7Ijl8ZybSXqsAYV0Jurp89XWSjWLrZ9k54wufJQo5KILg==",
+      "dependencies": {
+        "@jupyter-widgets/base": ">=2.0.0 <7.0.0",
+        "@jupyterlab/rendermime-interfaces": "^1.3.0 || ^2.0.0 || ^3.0.0",
+        "@lumino/messaging": "^1.2.3",
+        "@lumino/widgets": "^1.8.1",
+        "lodash": "^4.17.4",
+        "plotly.js": "^2.27.0"
+      }
+    },
+    "node_modules/jupyterlab-plotly/node_modules/@lumino/commands": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.21.1.tgz",
+      "integrity": "sha512-d1zJmwz5bHU0BM/Rl3tRdZ7/WgXnFB0bM7x7Bf0XDlmX++jnU9k0j3mh6/5JqCGLmIApKCRwVqSaV7jPmSJlcQ==",
+      "dependencies": {
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4",
+        "@lumino/domutils": "^1.8.2",
+        "@lumino/keyboard": "^1.8.2",
+        "@lumino/signaling": "^1.11.1",
+        "@lumino/virtualdom": "^1.14.3"
+      }
+    },
+    "node_modules/jupyterlab-plotly/node_modules/@lumino/coreutils": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.12.1.tgz",
+      "integrity": "sha512-JLu3nTHzJk9N8ohZ85u75YxemMrmDzJdNgZztfP7F7T7mxND3YVNCkJG35a6aJ7edu1sIgCjBxOvV+hv27iYvQ==",
+      "peerDependencies": {
+        "crypto": "1.0.1"
+      }
+    },
+    "node_modules/jupyterlab-plotly/node_modules/@lumino/disposable": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.10.4.tgz",
+      "integrity": "sha512-4ZxyYcyzUS+ZeB2KAH9oAH3w0DUUceiVr+FIZHZ2TAYGWZI/85WlqJtfm0xjwEpCwLLW1TDqJrISuZu3iMmVMA==",
+      "dependencies": {
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/signaling": "^1.11.1"
+      }
+    },
+    "node_modules/jupyterlab-plotly/node_modules/@lumino/dragdrop": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.14.5.tgz",
+      "integrity": "sha512-LC5xB82+xGF8hFyl716TMpV32OIMIMl+s3RU1PaqDkD6B7PkgiVk6NkJ4X9/GcEvl2igkvlGQt/3L7qxDAJNxw==",
+      "dependencies": {
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4"
+      }
+    },
+    "node_modules/jupyterlab-plotly/node_modules/@lumino/keyboard": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.8.2.tgz",
+      "integrity": "sha512-Dy+XqQ1wXbcnuYtjys5A0pAqf4SpAFl9NY6owyIhXAo0Va7w3LYp3jgiP1xAaBAwMuUppiUAfrbjrysZuZ625g=="
+    },
+    "node_modules/jupyterlab-plotly/node_modules/@lumino/signaling": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.11.1.tgz",
+      "integrity": "sha512-YCUmgw08VoyMN5KxzqPO3KMx+cwdPv28tAN06C0K7Q/dQf+oufb1XocuhZb5selTrTmmuXeizaYxgLIQGdS1fA==",
+      "dependencies": {
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/properties": "^1.8.2"
+      }
+    },
+    "node_modules/jupyterlab-plotly/node_modules/@lumino/virtualdom": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.14.3.tgz",
+      "integrity": "sha512-5joUC1yuxeXbpfbSBm/OR8Mu9HoTo6PDX0RKqzlJ9o97iml7zayFN/ynzcxScKGQAo9iaXOY8uVIvGUT8FnsGw==",
+      "dependencies": {
+        "@lumino/algorithm": "^1.9.2"
+      }
+    },
+    "node_modules/jupyterlab-plotly/node_modules/@lumino/widgets": {
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.37.2.tgz",
+      "integrity": "sha512-NHKu1NBDo6ETBDoNrqSkornfUCwc8EFFzw6+LWBfYVxn2PIwciq2SdiJGEyNqL+0h/A9eVKb5ui5z4cwpRekmQ==",
+      "dependencies": {
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/commands": "^1.21.1",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.4",
+        "@lumino/domutils": "^1.8.2",
+        "@lumino/dragdrop": "^1.14.5",
+        "@lumino/keyboard": "^1.8.2",
+        "@lumino/messaging": "^1.10.3",
+        "@lumino/properties": "^1.8.2",
+        "@lumino/signaling": "^1.11.1",
+        "@lumino/virtualdom": "^1.14.3"
+      }
+    },
     "node_modules/katex": {
       "version": "0.15.6",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.15.6.tgz",
@@ -26961,6 +28051,11 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "node_modules/keyv": {
       "version": "4.5.3",
@@ -27467,6 +28562,22 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-limit": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
+      "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
+      "dependencies": {
+        "once": "~1.3.0"
+      }
+    },
+    "node_modules/map-limit/node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/map-obj": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -27649,6 +28760,14 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/math-log2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
+      "integrity": "sha512-9W0yGtkaMAkf74XGYVy4Dqw3YUMnTNB2eeiw9aQbUl4A3KmuCEHTt2DgAB07ENzOYAjsYSAYufkAq0Zd+jU7zA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/mdast": {
@@ -29261,6 +30380,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/mouse-change": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
+      "integrity": "sha512-vpN0s+zLL2ykyyUDh+fayu9Xkor5v/zRD9jhSqjRS1cJTGS0+oakVZzNm5n19JvvEj0you+MXlYTpNxUDQUjkQ==",
+      "dependencies": {
+        "mouse-event": "^1.0.0"
+      }
+    },
+    "node_modules/mouse-event": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
+      "integrity": "sha512-ItUxtL2IkeSKSp9cyaX2JLUuKk2uMoxBg4bbOWVd29+CskYJR9BGsUqtXenNzKbnDshvupjUewDIYVrOB6NmGw=="
+    },
+    "node_modules/mouse-event-offset": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
+      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w=="
+    },
+    "node_modules/mouse-wheel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
+      "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
+      "dependencies": {
+        "right-now": "^1.0.0",
+        "signum": "^1.0.0",
+        "to-px": "^1.0.1"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -29282,6 +30429,20 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/mumath": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
+      "integrity": "sha512-VAFIOG6rsxoc7q/IaY3jdjmrsuX9f15KlRLYTHmixASBZkZEKC1IFqE2BC5CdhXmK6WLM1Re33z//AGmeRI6FA==",
+      "deprecated": "Redundant dependency in your project.",
+      "dependencies": {
+        "almost-equal": "^1.1.0"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -29729,6 +30890,11 @@
         "node": "^14 || ^16 || >=18"
       }
     },
+    "node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -29744,6 +30910,30 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/nbtx/-/nbtx-0.2.3.tgz",
       "integrity": "sha512-Gi7R1rFty2sCiTuHYHsmK0pdCqZ41LV152O26eKqiDuCxLAU1TbxVFXIHvJjYyJaBUXUdmZmfym6H3eaE+saZA=="
+    },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -29768,6 +30958,11 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -29906,6 +31101,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
+      "integrity": "sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA=="
+    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -30035,6 +31235,17 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/number-is-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
+      "integrity": "sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==",
+      "dependencies": {
+        "is-finite": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/nwsapi": {
@@ -30519,6 +31730,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/parenthesis": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
+      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+    },
     "node_modules/parse-entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
@@ -30567,10 +31783,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
+      "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
+      "dependencies": {
+        "pick-by-alias": "^1.2.0"
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
+    },
+    "node_modules/parse-unit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg=="
     },
     "node_modules/parse5": {
       "version": "7.1.2",
@@ -30971,6 +32205,18 @@
         "node": "*"
       }
     },
+    "node_modules/pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/peek-stream": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -30987,6 +32233,11 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/periscopic": {
       "version": "3.1.0",
@@ -31013,6 +32264,11 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/pick-by-alias": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
+      "integrity": "sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -31081,6 +32337,130 @@
         "pathe": "^1.1.0"
       }
     },
+    "node_modules/plotly.js": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.28.0.tgz",
+      "integrity": "sha512-fEvAapXhFTFO/PM5LnUvoG+tgOxRjjW7C7nHwVaDLKfq0F+SF/p3zRgo7vKwk9588WfgEHvuk6yRnp1mxZ+YSw==",
+      "dependencies": {
+        "@plotly/d3": "3.8.1",
+        "@plotly/d3-sankey": "0.7.2",
+        "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/mapbox-gl": "v1.13.4",
+        "@turf/area": "^6.4.0",
+        "@turf/bbox": "^6.4.0",
+        "@turf/centroid": "^6.0.2",
+        "base64-arraybuffer": "^1.0.2",
+        "canvas-fit": "^1.5.0",
+        "color-alpha": "1.0.4",
+        "color-normalize": "1.5.0",
+        "color-parse": "1.3.8",
+        "color-rgba": "2.1.1",
+        "country-regex": "^1.1.0",
+        "d3-force": "^1.2.1",
+        "d3-format": "^1.4.5",
+        "d3-geo": "^1.12.1",
+        "d3-geo-projection": "^2.9.0",
+        "d3-hierarchy": "^1.1.9",
+        "d3-interpolate": "^3.0.1",
+        "d3-time": "^1.1.0",
+        "d3-time-format": "^2.2.3",
+        "fast-isnumeric": "^1.1.4",
+        "gl-mat4": "^1.2.0",
+        "gl-text": "^1.3.1",
+        "glslify": "^7.1.1",
+        "has-hover": "^1.0.1",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^4.0.0",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "native-promise-only": "^0.8.1",
+        "parse-svg-path": "^0.1.2",
+        "point-in-polygon": "^1.1.0",
+        "polybooljs": "^1.2.0",
+        "probe-image-size": "^7.2.3",
+        "regl": "npm:@plotly/regl@^2.1.2",
+        "regl-error2d": "^2.0.12",
+        "regl-line2d": "^3.1.2",
+        "regl-scatter2d": "^3.3.1",
+        "regl-splom": "^1.0.14",
+        "strongly-connected-components": "^1.0.1",
+        "superscript-text": "^1.0.0",
+        "svg-path-sdf": "^1.1.3",
+        "tinycolor2": "^1.4.2",
+        "to-px": "1.0.1",
+        "topojson-client": "^3.1.0",
+        "webgl-context": "^2.2.0",
+        "world-calendars": "^1.0.3"
+      }
+    },
+    "node_modules/plotly.js/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/plotly.js/node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "node_modules/plotly.js/node_modules/d3-force": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
+      "dependencies": {
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
+      }
+    },
+    "node_modules/plotly.js/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/plotly.js/node_modules/d3-geo": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
+      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/plotly.js/node_modules/d3-hierarchy": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+    },
+    "node_modules/plotly.js/node_modules/d3-quadtree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+    },
+    "node_modules/plotly.js/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/plotly.js/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/plotly.js/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
+    },
     "node_modules/polished": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/polished/-/polished-4.2.2.tgz",
@@ -31092,6 +32472,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/polybooljs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
+      "integrity": "sha512-mKjR5nolISvF+q2BtC1fi/llpxBPTQ3wLWN8+ldzdw2Hocpc8C72ZqnamCM4Z6z+68GVVjkeM01WJegQmZ8MEQ=="
     },
     "node_modules/postcss": {
       "version": "8.4.30",
@@ -31352,6 +32737,11 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "node_modules/preferred-pm": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.1.2.tgz",
@@ -31574,6 +32964,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -31633,6 +33033,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -31898,6 +33303,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/ramda": {
@@ -32623,6 +34041,82 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/regl": {
+      "name": "@plotly/regl",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
+      "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw=="
+    },
+    "node_modules/regl-error2d": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
+      "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "color-normalize": "^1.5.0",
+        "flatten-vertex-data": "^1.0.2",
+        "object-assign": "^4.1.1",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "node_modules/regl-line2d": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.2.tgz",
+      "integrity": "sha512-nmT7WWS/WxmXAQMkgaMKWXaVmwJ65KCrjbqHGOUjjqQi6shfT96YbBOvelXwO9hG7/hjvbzjtQ2UO0L3e7YaXQ==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "array-find-index": "^1.0.2",
+        "array-normalize": "^1.1.4",
+        "color-normalize": "^1.5.0",
+        "earcut": "^2.1.5",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0"
+      }
+    },
+    "node_modules/regl-scatter2d": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
+      "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
+      "dependencies": {
+        "@plotly/point-cluster": "^3.1.9",
+        "array-range": "^1.0.1",
+        "array-rearrange": "^2.2.2",
+        "clamp": "^1.0.1",
+        "color-id": "^1.1.0",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "is-iexplorer": "^1.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "node_modules/regl-splom": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
+      "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "array-range": "^1.0.1",
+        "color-alpha": "^1.0.4",
+        "flatten-vertex-data": "^1.0.2",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "raf": "^3.4.1",
+        "regl-scatter2d": "^3.2.3"
+      }
+    },
     "node_modules/rehype-format": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-4.0.1.tgz",
@@ -33212,6 +34706,14 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -33254,6 +34756,11 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/right-now": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -33649,6 +35156,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shallow-copy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -33701,6 +35213,11 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/signum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
+      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -34137,6 +35654,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -34167,6 +35692,14 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true
+    },
+    "node_modules/static-eval": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
+      "integrity": "sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==",
+      "dependencies": {
+        "escodegen": "^2.1.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -34218,11 +35751,31 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "dev": true
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/stream-slice": {
       "version": "0.1.2",
@@ -34262,6 +35815,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string-split-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
+      "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+      "dependencies": {
+        "parenthesis": "^3.1.5"
       }
     },
     "node_modules/string-width": {
@@ -34497,6 +36058,11 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strongly-connected-components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
+      "integrity": "sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA=="
+    },
     "node_modules/style-loader": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.3.tgz",
@@ -34583,6 +36149,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/supercluster": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "dependencies": {
+        "kdbush": "^3.0.0"
+      }
+    },
+    "node_modules/superscript-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+      "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ=="
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -34603,6 +36182,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
+    },
+    "node_modules/svg-path-bounds": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
+      "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
+      "dependencies": {
+        "abs-svg-path": "^0.1.1",
+        "is-svg-path": "^1.0.1",
+        "normalize-svg-path": "^1.0.0",
+        "parse-svg-path": "^0.1.2"
+      }
+    },
+    "node_modules/svg-path-bounds/node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
+    "node_modules/svg-path-sdf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
+      "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
+      "dependencies": {
+        "bitmap-sdf": "^1.0.0",
+        "draw-svg-path": "^1.0.0",
+        "is-svg-path": "^1.0.1",
+        "parse-svg-path": "^0.1.2",
+        "svg-path-bounds": "^1.0.1"
       }
     },
     "node_modules/swc-loader": {
@@ -35128,7 +36743,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -35161,6 +36775,11 @@
       "integrity": "sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==",
       "dev": true
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+    },
     "node_modules/tinypool": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.5.0.tgz",
@@ -35169,6 +36788,11 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "node_modules/tinyspy": {
       "version": "2.1.1",
@@ -35216,6 +36840,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/to-float32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
+      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg=="
+    },
+    "node_modules/to-px": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
+      "integrity": "sha512-2y3LjBeIZYL19e5gczp14/uRWFDtDUErJPVN3VU9a7SJO+RjGRtYR47aMN2bZgGlxvW4ZcEz2ddUPVHXcMfuXw==",
+      "dependencies": {
+        "parse-unit": "^1.0.1"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -35247,6 +36884,24 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "dev": true
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
@@ -35724,6 +37379,11 @@
         "win32"
       ]
     },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -35837,8 +37497,16 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "node_modules/typedarray-pool": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.2.2",
@@ -36235,6 +37903,11 @@
         "webpack-virtual-modules": "^0.5.0"
       }
     },
+    "node_modules/unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
+    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -36272,6 +37945,11 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/update-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
+      "integrity": "sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -36891,6 +38569,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -36946,6 +38634,11 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/weak-map": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
+      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
+    },
     "node_modules/web-encoding": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
@@ -36978,6 +38671,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
+    },
+    "node_modules/webgl-context": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
+      "integrity": "sha512-q/fGIivtqTT7PEoF07axFIlHNk/XCPaYpq64btnepopSWvKNFkoORlQYgqDigBIuGA1ExnFd/GnSUnBNEPQY7Q==",
+      "dependencies": {
+        "get-canvas-context": "^1.0.1"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -37383,6 +39084,14 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
+    },
+    "node_modules/world-calendars": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
+      "integrity": "sha512-sAjLZkBnsbHkHWVhrsCU5Sa/EVuf9QqgvrN8zyJ2L/F9FR9Oc6CvVK0674+PGAtmmmYQMH98tCUSO4QLQv3/TQ==",
+      "dependencies": {
+        "object-assign": "^4.1.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -37936,6 +39645,7 @@
         "@scienceicons/react": "^0.0.6",
         "buffer": "^6.0.3",
         "classnames": "^2.3.2",
+        "jupyterlab-plotly": "^5.18.0",
         "myst-common": "^1.1.18",
         "myst-config": "^1.1.18",
         "myst-frontmatter": "^1.1.18",
@@ -37951,7 +39661,6 @@
         "thebe-react": "^0.4.5",
         "unist-util-select": "^4.0.3"
       },
-      "devDependencies": {},
       "engines": {
         "node": ">=16"
       },

--- a/packages/jupyter/package.json
+++ b/packages/jupyter/package.json
@@ -29,6 +29,7 @@
     "@scienceicons/react": "^0.0.6",
     "buffer": "^6.0.3",
     "classnames": "^2.3.2",
+    "jupyterlab-plotly": "^5.18.0",
     "myst-common": "^1.1.18",
     "myst-config": "^1.1.18",
     "myst-frontmatter": "^1.1.18",
@@ -49,6 +50,5 @@
     "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
     "react": "^16.8 || ^17.0 || ^18.0",
     "react-dom": "^16.8 || ^17.0 || ^18.0"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/jupyter/src/globals.d.ts
+++ b/packages/jupyter/src/globals.d.ts
@@ -1,0 +1,3 @@
+declare module 'jupyterlab-plotly/lib/plotly-renderer.js';
+declare module 'jupyterlab-plotly/dist/index.js';
+declare module 'plotly.js/dist/plotly';

--- a/packages/jupyter/src/jupyter.tsx
+++ b/packages/jupyter/src/jupyter.tsx
@@ -78,29 +78,24 @@ function PassiveOutputRenderer({
 }) {
   const rendermime = core.makeRenderMimeRegistry();
 
-  // const MIME_TYPE = 'application/vnd.plotly.v1+json';
-  // rendermime.addFactory(plotly.rendererFactory, 10);
-
   const cell = useRef(new core.PassiveCellRenderer(id, rendermime, undefined));
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!ref.current) return;
     // eslint-disable-next-line import/no-extraneous-dependencies
-    import('plotly.js/dist/plotly').then(() => {
-      import('jupyterlab-plotly/lib/plotly-renderer.js').then(
-        (module: { rendererFactory: IRenderMime.IRendererFactory }) => {
-          console.debug('Jupyter: Adding plotly renderer factory to rendermime registry', {
-            module,
-          });
-          rendermime.addFactory(module.rendererFactory, 1);
-          console.debug('Jupyter: Attaching cell to DOM', { ref: ref.current });
-          cell.current.attachToDOM(ref.current ?? undefined, true);
-          console.log('Jupyter: Rendering cell', module.rendererFactory);
-          cell.current.render(data); //core?.stripWidgets(data) ??
-        },
-      );
-    });
+    import('jupyterlab-plotly/lib/plotly-renderer.js').then(
+      (module: { rendererFactory: IRenderMime.IRendererFactory }) => {
+        console.debug('Jupyter: Adding plotly renderer factory to rendermime registry', {
+          module,
+        });
+        rendermime.addFactory(module.rendererFactory, 41);
+        console.debug('Jupyter: Attaching cell to DOM', { ref: ref.current });
+        cell.current.attachToDOM(ref.current ?? undefined, true);
+        console.log('Jupyter: Rendering cell', module.rendererFactory);
+        cell.current.render(core?.stripWidgets(data) ?? data);
+      },
+    );
   }, [ref]);
 
   return <div ref={ref} data-thebe-passive-ref="true" />;

--- a/packages/jupyter/src/plotly.ts
+++ b/packages/jupyter/src/plotly.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import type { IRenderMime, IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import type { IOutput } from '@jupyterlab/nbformat';
+
+export function useLoadPlotly() {
+  const [plotly, setPlotly] = useState<
+    { rendererFactory: IRenderMime.IRendererFactory } | undefined
+  >();
+
+  useEffect(() => {
+    if (plotly) return;
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    import('jupyterlab-plotly/lib/plotly-renderer.js').then(
+      (module: { rendererFactory: IRenderMime.IRendererFactory }) => {
+        console.debug('Jupyter: Adding plotly renderer factory to rendermime registry', {
+          module,
+        });
+        setPlotly(module);
+      },
+    );
+  }, [plotly]);
+
+  return { plotly };
+}
+
+const PLOTLY_MIMETYPE = 'application/vnd.plotly.v1+json';
+
+export function isPlotly(outputs: IOutput[]) {
+  return outputs.some((output) => Object.keys(output.data ?? []).includes(PLOTLY_MIMETYPE));
+}
+
+export function usePlotlyPassively(rendermime: IRenderMimeRegistry, outputs: IOutput[]) {
+  const [loaded, setLoaded] = useState(false);
+
+  const isPlotlyOutput = isPlotly(outputs);
+
+  useEffect(() => {
+    if (loaded || !isPlotlyOutput) return;
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    import('jupyterlab-plotly/lib/plotly-renderer.js').then(
+      (module: { rendererFactory: IRenderMime.IRendererFactory }) => {
+        console.debug('Jupyter: Adding plotly renderer factory to rendermime registry', {
+          module,
+        });
+        rendermime.addFactory(module.rendererFactory, 41);
+        setLoaded(true);
+      },
+    );
+  }, [loaded, isPlotlyOutput]);
+
+  return { loaded };
+}

--- a/patches/jupyterlab-plotly+5.18.0.patch
+++ b/patches/jupyterlab-plotly+5.18.0.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/jupyterlab-plotly/lib/plotly-renderer.js b/node_modules/jupyterlab-plotly/lib/plotly-renderer.js
+index 23baa49..43c857a 100644
+--- a/node_modules/jupyterlab-plotly/lib/plotly-renderer.js
++++ b/node_modules/jupyterlab-plotly/lib/plotly-renderer.js
+@@ -110,12 +110,15 @@ export class RenderedPlotly extends Widget {
+         const loadPlotly = () => __awaiter(this, void 0, void 0, function* () {
+             if (RenderedPlotly.Plotly === null) {
+                 RenderedPlotly.Plotly = yield import("plotly.js/dist/plotly");
++                RenderedPlotly.Plotly = RenderedPlotly.Plotly.default;
+                 RenderedPlotly._resolveLoadingPlotly();
+             }
+             return RenderedPlotly.loadingPlotly;
+         });
+         return loadPlotly()
+-            .then(() => RenderedPlotly.Plotly.react(this.node, data, layout, config))
++            .then(() => {
++                return RenderedPlotly.Plotly.react(this.node, data, layout, config)
++            })
+             .then((plot) => {
+             this.showGraph();
+             this.hideImage();


### PR DESCRIPTION
Plotly plots are not working in `myst-theme` as the rendermime factory is not being registered.
Recent changes to plotly (as compared to pre-juptyerlab 4 extensions) make it more tricky to bring in the plotly js renderer from the extension package.

For anything more than a short term fix here we need to move the myst-theme towards making proper use of the jupyterlab extension mechanism via federated modules, so that we can configure in myst/environment which extensions to load and have those included in the website build appropriately. As discussed with @agoose77 @rowanc1 

As a short term solution, this PR makes a small patch to the plotly jupyterlab extension module in order to load this dynamically.

In passive mode, the module is only loaded when a plotly mimetype is seen in an `IOutput[]`, whereas in active mode (i.e. after connecting to a kernel) we always load the plotly library.