### PR TITLE
🛠 fix notebook build process

### DIFF
--- a/.changeset/shy-buses-sit.md
+++ b/.changeset/shy-buses-sit.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/jupyter': patch
+---
+
+Fix for [322](https://github.com/executablebooks/myst-theme/issues/322) waiting for plotly during notebook build

--- a/packages/jupyter/src/plotly.ts
+++ b/packages/jupyter/src/plotly.ts
@@ -30,9 +30,9 @@ export function isPlotly(outputs: IOutput[]) {
 }
 
 export function usePlotlyPassively(rendermime: IRenderMimeRegistry, outputs: IOutput[]) {
-  const [loaded, setLoaded] = useState(false);
-
   const isPlotlyOutput = isPlotly(outputs);
+  // skip loading for non plotly outputs
+  const [loaded, setLoaded] = useState(!isPlotlyOutput);
 
   useEffect(() => {
     if (loaded || !isPlotlyOutput) return;


### PR DESCRIPTION
Recent changes to plotly introduced a problem for noteobok based pages at execution time, this PR fixes that ensuring that plotly is loaded before the notebook is deemed built. This is due to the fact that we expect a rendermime registry to be constructed during the notebook build phase, which in turn needs to wait on plotly.

fixes #322 