### PR TITLE
🏷 Pull frontmatter from proper key

### DIFF
--- a/.changeset/modern-weeks-repeat.md
+++ b/.changeset/modern-weeks-repeat.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/book': patch
+---
+
+Migrated to V2 Remix meta function pattern

--- a/.changeset/ninety-planes-pump.md
+++ b/.changeset/ninety-planes-pump.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/common': minor
+'@myst-theme/site': minor
+---
+
+Migrated to meta helper functions to the Remix V2 pattern, old meta helpers functions are still available with a `_v1` suffix.

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -17,8 +17,9 @@ export function getProject(
   projectSlug?: string,
 ): ManifestProject | undefined {
   if (!config) return undefined;
-  if (!projectSlug) return config.projects?.[0];
-  const project = config.projects?.find((p) => p.slug === projectSlug);
+  if (!config.projects || config.projects.length === 0) return undefined;
+  if (!projectSlug) return config.projects[0];
+  const project = config.projects?.find((p) => p.slug === projectSlug) ?? config.projects[0];
   return project;
 }
 

--- a/packages/site/src/seo/meta.ts
+++ b/packages/site/src/seo/meta.ts
@@ -1,7 +1,8 @@
-import type { HtmlMetaDescriptor } from '@remix-run/react';
+import type { HtmlMetaDescriptor, V2_MetaDescriptor } from '@remix-run/react';
 
 type SocialSite = {
   title: string;
+  description?: string;
   twitter?: string;
 };
 
@@ -20,15 +21,38 @@ function allDefined(meta: Record<string, string | null | undefined>): HtmlMetaDe
   return Object.fromEntries(Object.entries(meta).filter(([, v]) => v)) as HtmlMetaDescriptor;
 }
 
-export function getMetaTagsForSite({ title, twitter }: SocialSite): HtmlMetaDescriptor {
+export function getMetaTagsForSite_V1({
+  title,
+  description,
+  twitter,
+}: SocialSite): HtmlMetaDescriptor {
   const meta = {
     title,
+    description,
     'twitter:site': twitter ? `@${twitter.replace('@', '')}` : undefined,
   };
   return allDefined(meta);
 }
 
-export function getMetaTagsForArticle({
+export function getMetaTagsForSite({
+  title,
+  description,
+  twitter,
+}: SocialSite): V2_MetaDescriptor[] {
+  const meta: V2_MetaDescriptor[] = [
+    { title },
+    { property: 'og:title', content: title },
+    { name: 'generator', content: 'mystmd' },
+  ];
+  if (description) {
+    meta.push({ name: 'description', content: description });
+    meta.push({ property: 'og:description', content: description });
+  }
+  if (twitter) meta.push({ name: 'twitter:site', content: `@${twitter.replace('@', '')}` });
+  return meta;
+}
+
+export function getMetaTagsForArticle_V1({
   origin,
   url,
   title,
@@ -54,4 +78,40 @@ export function getMetaTagsForArticle({
     'twitter:alt': title,
   };
   return allDefined(meta);
+}
+
+export function getMetaTagsForArticle({
+  origin,
+  url,
+  title,
+  description,
+  image,
+  twitter,
+  keywords,
+}: SocialArticle): V2_MetaDescriptor[] {
+  const meta: V2_MetaDescriptor[] = [
+    { title },
+    { property: 'og:title', content: title },
+    { name: 'generator', content: 'mystmd' },
+  ];
+  if (description) {
+    meta.push({ name: 'description', content: description });
+    meta.push({ property: 'og:description', content: description });
+  }
+  if (keywords) meta.push({ name: 'keywords', content: keywords.join(', ') });
+  if (origin && url) meta.push({ property: 'og:url', content: `${origin}${url}` });
+  if (image) {
+    meta.push({ name: 'image', content: image });
+    meta.push({ property: 'og:image', content: image });
+  }
+  if (twitter) {
+    meta.push({ name: 'twitter:card', content: image ? 'summary_large_image' : 'summary' });
+    meta.push({ name: 'twitter:creator', content: `@${twitter.replace('@', '')}` });
+    meta.push({ name: 'twitter:title', content: title });
+    if (description) meta.push({ name: 'twitter:description', content: description });
+    if (image) meta.push({ name: 'twitter:image', content: image });
+    meta.push({ name: 'twitter:alt', content: title });
+  }
+
+  return meta;
 }

--- a/themes/article/app/root.tsx
+++ b/themes/article/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction, LoaderFunction } from '@remix-run/node';
+import type { LinksFunction, MetaFunction, LoaderFunction, V2_MetaFunction } from '@remix-run/node';
 import tailwind from '~/styles/app.css';
 import thebeCoreCss from 'thebe-core/dist/lib/thebe-core.css';
 import { getConfig } from '~/utils/loaders.server';
@@ -14,9 +14,10 @@ import {
 import { Outlet, useLoaderData } from '@remix-run/react';
 export { AppCatchBoundary as CatchBoundary } from '@myst-theme/site';
 
-export const meta: MetaFunction = ({ data }) => {
+export const meta: V2_MetaFunction = ({ data }) => {
   return getMetaTagsForSite({
     title: data?.config?.title,
+    description: data?.config?.description,
     twitter: data?.config?.options?.twitter,
   });
 };

--- a/themes/article/app/routes/_index.tsx
+++ b/themes/article/app/routes/_index.tsx
@@ -1,19 +1,45 @@
-import { ProjectPageCatchBoundary, responseNoArticle, responseNoSite } from '@myst-theme/site';
+import {
+  ProjectPageCatchBoundary,
+  getMetaTagsForArticle,
+  responseNoArticle,
+  responseNoSite,
+} from '@myst-theme/site';
 import Page from './$';
 import { ArticlePageAndNavigation } from '../components/ArticlePageAndNavigation';
 import { getConfig, getPage } from '../utils/loaders.server';
-import type { LoaderFunction } from '@remix-run/node';
+import type { LoaderFunction, V2_MetaFunction } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
+import { SiteManifest } from 'myst-config';
+import { getProject } from '@myst-theme/common';
 export { links } from './$';
+
+type ManifestProject = Required<SiteManifest>['projects'][0];
+
+export const meta: V2_MetaFunction = ({ data, location }) => {
+  if (!data) return [];
+
+  const config: SiteManifest = data.config;
+  const project: ManifestProject = data.project;
+
+  return getMetaTagsForArticle({
+    origin: '',
+    url: location.pathname,
+    title: config?.title ?? project.title,
+    description: config.description ?? project.description ?? undefined,
+    image: (project.thumbnailOptimized || project.thumbnail) ?? undefined,
+    keywords: config.keywords ?? project.keywords ?? [],
+    twitter: config?.options?.twitter,
+  });
+};
 
 export const loader: LoaderFunction = async ({ params, request }) => {
   const config = await getConfig();
   if (!config) throw responseNoSite();
-  const project = config?.projects?.[0];
+  const project = getProject(config);
   if (!project) throw responseNoArticle();
   if (project.slug) return redirect(`/${project.slug}`);
   const page = await getPage(request, { slug: project.index });
-  return page;
+  return { config, project, page };
 };
 
 export default Page;

--- a/themes/article/remix.config.dev.js
+++ b/themes/article/remix.config.dev.js
@@ -63,5 +63,6 @@ module.exports = {
     v2_routeConvention: true,
     v2_normalizeFormMethod: true,
     v2_headers: true,
+    v2_meta: true,
   },
 };

--- a/themes/article/remix.config.prod.js
+++ b/themes/article/remix.config.prod.js
@@ -11,5 +11,6 @@ module.exports = {
     v2_routeConvention: true,
     v2_normalizeFormMethod: true,
     v2_headers: true,
+    v2_meta: true,
   },
 };

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction, LoaderFunction } from '@remix-run/node';
+import type { LinksFunction, V2_MetaFunction, LoaderFunction } from '@remix-run/node';
 import tailwind from '~/styles/app.css';
 import thebeCoreCss from 'thebe-core/dist/lib/thebe-core.css';
 import { getConfig } from '~/utils/loaders.server';
@@ -13,13 +13,6 @@ import {
 } from '@myst-theme/site';
 import { Outlet, useLoaderData } from '@remix-run/react';
 export { AppCatchBoundary as CatchBoundary } from '@myst-theme/site';
-
-export const meta: MetaFunction = ({ data }) => {
-  return getMetaTagsForSite({
-    title: data?.config?.title,
-    twitter: data?.config?.options?.twitter,
-  });
-};
 
 export const links: LinksFunction = () => {
   return [

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -14,6 +14,14 @@ import {
 import { Outlet, useLoaderData } from '@remix-run/react';
 export { AppCatchBoundary as CatchBoundary } from '@myst-theme/site';
 
+export const meta: V2_MetaFunction = ({ data }) => {
+  return getMetaTagsForSite({
+    title: data?.config?.title,
+    description: data?.config?.description,
+    twitter: data?.config?.options?.twitter,
+  });
+};
+
 export const links: LinksFunction = () => {
   return [
     { rel: 'stylesheet', href: tailwind },

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -27,14 +27,16 @@ import { ComputeOptionsProvider, ThebeLoaderAndServer } from '@myst-theme/jupyte
 
 export const meta: MetaFunction = (args) => {
   const config = args.parentsData?.root?.config as SiteManifest | undefined;
-  const data = args.data as PageLoader | undefined;
-  if (!config || !data || !data.frontmatter) return {};
+  const data = args.data;
+  if (!config || !data) return {};
+  const frontmatter = (data.page as PageLoader).frontmatter;
+  if (!frontmatter) return {};
   return getMetaTagsForArticle({
     origin: '',
     url: args.location.pathname,
-    title: `${data.frontmatter.title} - ${config?.title}`,
-    description: data.frontmatter.description,
-    image: (data.frontmatter.thumbnailOptimized || data.frontmatter.thumbnail) ?? undefined,
+    title: `${frontmatter.title} - ${config?.title}`,
+    description: frontmatter.description,
+    image: (frontmatter.thumbnailOptimized || frontmatter.thumbnail) ?? undefined,
   });
 };
 

--- a/themes/book/app/routes/_index.tsx
+++ b/themes/book/app/routes/_index.tsx
@@ -1,19 +1,45 @@
-import { KatexCSS, responseNoArticle, responseNoSite } from '@myst-theme/site';
-import type { LinksFunction, LoaderFunction } from '@remix-run/node';
-import { redirect } from '@remix-run/node';
+import {
+  KatexCSS,
+  getMetaTagsForArticle,
+  responseNoArticle,
+  responseNoSite,
+} from '@myst-theme/site';
+import type { LinksFunction, LoaderFunction, V2_MetaFunction } from '@remix-run/node';
+import { json, redirect } from '@remix-run/node';
 import { getConfig, getPage } from '~/utils/loaders.server';
 import Page from './$';
+import { SiteManifest } from 'myst-config';
+import { getProject } from '@myst-theme/common';
+
+type ManifestProject = Required<SiteManifest>['projects'][0];
+
+export const meta: V2_MetaFunction = ({ data, location }) => {
+  if (!data) return [];
+
+  const config: SiteManifest = data.config;
+  const project: ManifestProject = data.project;
+
+  return getMetaTagsForArticle({
+    origin: '',
+    url: location.pathname,
+    title: config?.title ?? project.title,
+    description: config.description ?? project.description ?? undefined,
+    image: (project.thumbnailOptimized || project.thumbnail) ?? undefined,
+    keywords: config.keywords ?? project.keywords ?? [],
+    twitter: config?.options?.twitter,
+  });
+};
 
 export const links: LinksFunction = () => [KatexCSS];
 
 export const loader: LoaderFunction = async ({ params, request }) => {
   const config = await getConfig();
   if (!config) throw responseNoSite();
-  const project = config?.projects?.[0];
+  const project = getProject(config);
   if (!project) throw responseNoArticle();
   if (project.slug) return redirect(`/${project.slug}`);
   const page = await getPage(request, { slug: project.index });
-  return { page, project };
+  return json({ config, page, project });
 };
 
 export default Page;

--- a/themes/book/remix.config.dev.js
+++ b/themes/book/remix.config.dev.js
@@ -63,5 +63,6 @@ module.exports = {
     v2_routeConvention: true,
     v2_normalizeFormMethod: true,
     v2_headers: true,
+    v2_meta: true,
   },
 };

--- a/themes/book/remix.config.prod.js
+++ b/themes/book/remix.config.prod.js
@@ -11,5 +11,6 @@ module.exports = {
     v2_routeConvention: true,
     v2_normalizeFormMethod: true,
     v2_headers: true,
+    v2_meta: true,
   },
 };


### PR DESCRIPTION
In executablebooks/myst-theme#332, @choldgraf observed that opengraph metadata is missing from the static MyST sites. It turns out it's also missing from the dynamic routes too.

I believe the root cause is fixed by this PR, though I have not tested the static export!

Fixes executablebooks/myst-theme#332