### PR TITLE
⌨️ Add `keyboard` renderer

### DIFF
--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -46,6 +46,10 @@ type Aside = {
   type: 'aside';
 };
 
+type Keystrokes = {
+  type: 'keystrokes';
+};
+
 type BasicNodeRenderers = {
   text: NodeRenderer<spec.Text>;
   span: NodeRenderer<GenericNode>;
@@ -79,6 +83,7 @@ type BasicNodeRenderers = {
   captionNumber: NodeRenderer<CaptionNumber>;
   delete: NodeRenderer<Delete>;
   underline: NodeRenderer<Underline>;
+  keystrokes: NodeRenderer<Keystrokes>;
   smallcaps: NodeRenderer<SmallCaps>;
   // definitions
   definitionList: NodeRenderer<DefinitionList>;
@@ -374,6 +379,9 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
         <MyST ast={node.children} />
       </aside>
     );
+  },
+  keystrokes({ node }) {
+    return <kbd>{node.value}</kbd>;
   },
 };
 

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -46,8 +46,8 @@ type Aside = {
   type: 'aside';
 };
 
-type Keystrokes = {
-  type: 'keystrokes';
+type Keyboard = {
+  type: 'keyboard';
 };
 
 type BasicNodeRenderers = {
@@ -83,7 +83,7 @@ type BasicNodeRenderers = {
   captionNumber: NodeRenderer<CaptionNumber>;
   delete: NodeRenderer<Delete>;
   underline: NodeRenderer<Underline>;
-  keystrokes: NodeRenderer<Keystrokes>;
+  keyboard: NodeRenderer<Keyboard>;
   smallcaps: NodeRenderer<SmallCaps>;
   // definitions
   definitionList: NodeRenderer<DefinitionList>;
@@ -380,8 +380,9 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
       </aside>
     );
   },
-  keystrokes({ node }) {
-    return <kbd>{node.value}</kbd>;
+  keyboard({ node }) {
+    const valueNode = (node.children as GenericNode[])[0];
+    return <kbd>{valueNode.value}</kbd>;
   },
 };
 

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -382,7 +382,7 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
   },
   keyboard({ node }) {
     const valueNode = (node.children as GenericNode[])[0];
-    return <kbd>{valueNode.value}</kbd>;
+    return <kbd><MyST ast={node.children} /></kbd>;
   },
 };
 

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -381,8 +381,11 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
     );
   },
   keyboard({ node }) {
-    const valueNode = (node.children as GenericNode[])[0];
-    return <kbd><MyST ast={node.children} /></kbd>;
+    return (
+      <kbd>
+        <MyST ast={node.children} />
+      </kbd>
+    );
   },
 };
 


### PR DESCRIPTION
This PR is the sibling to executablebooks/mystmd#989, which adds a new `kbd`/`keyboard` role to MyST.