### PR TITLE
FIX: bump myst-spec

### DIFF
--- a/packages/jupyter/package.json
+++ b/packages/jupyter/package.json
@@ -33,7 +33,7 @@
     "myst-common": "^1.1.18",
     "myst-config": "^1.1.18",
     "myst-frontmatter": "^1.1.18",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "myst-spec-ext": "^1.1.18",
     "myst-to-react": "^0.7.0",
     "nanoid": "^4.0.2",

--- a/packages/myst-demo/package.json
+++ b/packages/myst-demo/package.json
@@ -33,7 +33,7 @@
     "myst-ext-tabs": "^1.0.4",
     "myst-frontmatter": "^1.1.18",
     "myst-parser": "^1.0.18",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "myst-to-docx": "^1.0.7",
     "myst-to-html": "^1.0.18",
     "myst-to-jats": "^1.0.19",

--- a/packages/myst-to-react/package.json
+++ b/packages/myst-to-react/package.json
@@ -27,7 +27,7 @@
     "classnames": "^2.3.2",
     "myst-common": "^1.1.18",
     "myst-config": "^1.1.18",
-    "myst-spec": "^0.0.4",
+    "myst-spec": "^0.0.5",
     "nanoid": "^4.0.2",
     "react-syntax-highlighter": "^15.5.0",
     "swr": "^2.1.5",


### PR DESCRIPTION
I'm not sure if this is the right solution: my intention is to avoid installing two copies of myst-spec when solving in a busy environment. We could also use
```json
"myst-spec": "^0.0.4 || ^0.0.5"
```

My assertion is that we're compatible with both myst-spec `0.0.4` and `0.0.5`.

This is part of work to unblock `jupyterlab-myst`
