### PR TITLE
👩‍🎨 Document accepts renderers as a prop

### DIFF
--- a/.changeset/famous-forks-run.md
+++ b/.changeset/famous-forks-run.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': patch
+---
+
+Add renderers as a prop to Document

--- a/packages/site/src/pages/Root.tsx
+++ b/packages/site/src/pages/Root.tsx
@@ -1,5 +1,6 @@
 import type { SiteManifest } from 'myst-config';
 import type { SiteLoader } from '@myst-theme/common';
+import type { NodeRenderer } from '@myst-theme/providers';
 import { BaseUrlProvider, SiteProvider, Theme, ThemeProvider } from '@myst-theme/providers';
 import {
   Links,
@@ -12,7 +13,7 @@ import {
   Link,
   NavLink,
 } from '@remix-run/react';
-import { DEFAULT_NAV_HEIGHT, renderers } from '../components/index.js';
+import { DEFAULT_NAV_HEIGHT, renderers as defaultRenderers } from '../components/index.js';
 import { Analytics } from '../seo/index.js';
 import { Error404 } from './Error404.js';
 import classNames from 'classnames';
@@ -26,6 +27,7 @@ export function Document({
   staticBuild,
   baseurl,
   top = DEFAULT_NAV_HEIGHT,
+  renderers = defaultRenderers,
 }: {
   children: React.ReactNode;
   scripts?: React.ReactNode;
@@ -35,6 +37,7 @@ export function Document({
   staticBuild?: boolean;
   baseurl?: string;
   top?: number;
+  renderers?: Record<string, NodeRenderer>;
 }) {
   const links = staticBuild
     ? {


### PR DESCRIPTION
This change adds the renderers prop, which defaults to the default must renderers collection. This enables users of this component to customize or add to the renderers included in the theme.