### PR TITLE
🧮 Require location on node source to enable jupyter computation

### DIFF
--- a/.changeset/giant-bugs-rest.md
+++ b/.changeset/giant-bugs-rest.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/jupyter': patch
+---
+
+Require location on node source to enable jupyter computation

--- a/packages/jupyter/src/decoration.tsx
+++ b/packages/jupyter/src/decoration.tsx
@@ -32,12 +32,14 @@ export function OutputDecoration({
   children,
   title = 'Jupyter Notebook',
   url,
+  location,
 }: {
   outputId: string;
   placeholder?: GenericNode;
   children?: React.ReactNode;
   title?: string;
   url?: string;
+  location?: string;
 }) {
   const { kind } = useCellExecution(outputId);
   const compute = useComputeOptions();
@@ -45,7 +47,10 @@ export function OutputDecoration({
   const top = useThemeTop();
   const baseurl = useBaseurl();
   const showComputeControls =
-    compute?.enabled && compute?.features.figureCompute && kind === SourceFileKind.Article;
+    compute?.enabled &&
+    compute?.features.figureCompute &&
+    kind === SourceFileKind.Article &&
+    location;
 
   if (showComputeControls) {
     return (

--- a/packages/jupyter/src/embed.tsx
+++ b/packages/jupyter/src/embed.tsx
@@ -11,6 +11,7 @@ export function Embed({ node }: { node: GenericNode }) {
       outputId={output.id}
       title={node.source?.title}
       url={node.source?.url}
+      location={node.source?.location}
     >
       <MyST ast={node.children} />
     </OutputDecoration>

--- a/packages/jupyter/src/figure.tsx
+++ b/packages/jupyter/src/figure.tsx
@@ -22,6 +22,7 @@ export function Figure({ node }: { node: GenericNode }) {
           placeholder={placeholder}
           title={node.source?.title}
           url={node.source?.url}
+          location={node.source?.location}
         >
           <MyST ast={others} />
         </OutputDecoration>


### PR DESCRIPTION
This PR prevents enabling the thebe power button on nodes where source `location` file is not available (e.g. externally cross-referenced figures)