### PR TITLE
🥉 Keep 3 node default for xref popup

### DIFF
--- a/.changeset/kind-months-drive.md
+++ b/.changeset/kind-months-drive.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Keep 3 node default for xref popup

--- a/packages/myst-to-react/src/crossReference.tsx
+++ b/packages/myst-to-react/src/crossReference.tsx
@@ -111,7 +111,7 @@ function useSelectNodes({ load, identifier }: { load?: boolean; identifier: stri
   if (!load) return;
   const { data, error } = useFetchMdast({ remote, url, remoteBaseUrl, dataUrl });
   const mdast = data?.mdast ?? references?.article;
-  const { nodes, htmlId } = selectMdastNodes(mdast, identifier);
+  const { nodes, htmlId } = selectMdastNodes(mdast, identifier, 3);
   return { htmlId, nodes, loading: remote && !data, error: remote && error };
 }
 


### PR DESCRIPTION
The 3-node default for `selectMdastNodes` was removed when pulling that function up to `myst-common`. This restores the limit here so we do not get overly long popups.