### PR TITLE
🥤 Use correct remoteBaseUrl on nested cross reference popups

### DIFF
--- a/.changeset/proud-waves-mix.md
+++ b/.changeset/proud-waves-mix.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Use correct remoteBaseUrl on nested cross reference popups

--- a/packages/myst-to-react/src/crossReference.tsx
+++ b/packages/myst-to-react/src/crossReference.tsx
@@ -135,8 +135,8 @@ export function CrossReferenceHover({
   const Link = useLinkProvider();
   const baseurl = useBaseurl();
   const parent = useXRefState();
-  const remote = parent.remote || remoteIn;
-  const remoteBaseUrl = parent.remoteBaseUrl || remoteBaseUrlIn;
+  const remoteBaseUrl = remoteBaseUrlIn ?? parent.remoteBaseUrl;
+  const remote = !!remoteBaseUrl || parent.remote || remoteIn;
   const url = parent.remote ? urlIn ?? parent.url : urlIn;
   const dataUrl = parent.remote ? dataUrlIn ?? parent.dataUrl : dataUrlIn;
   const external = !!remoteBaseUrl || (url?.startsWith('http') ?? false);


### PR DESCRIPTION
To reproduce this bug you need a MyST site with a cross reference to a second site that contains a cross reference to a third site. The theme will try to access the third site's content at the second site's base url.

You can recreate this with: `[](xref:mystmd#tbl:syntax-xref)`

This PR simply changes the order of base url resolution to prioritize the node's `remoteBaseUrl`, if defined, over the parent's `remoteBaseUrl`.