### PR TITLE
🎨 Add H5 and H6 styles

### DIFF
--- a/.changeset/nasty-hotels-burn.md
+++ b/.changeset/nasty-hotels-burn.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/styles': patch
+---
+
+Add H5 and H6 styles

--- a/styles/index.js
+++ b/styles/index.js
@@ -84,9 +84,13 @@ const themeExtensions = {
       css: {
         code: {
           fontWeight: '400',
-          '&::before, &::after': {
-            content: '',
-          }
+        },
+        // These code before/after elements are hard coded to remove the backticks, "`", that are in by default.
+        'code::before': {
+          content: '',
+        },
+        'code::after': {
+          content: '',
         },
         'blockquote p:first-of-type::before': { content: 'none' },
         'blockquote p:first-of-type::after': { content: 'none' },
@@ -98,10 +102,11 @@ const themeExtensions = {
           marginTop: '0.25rem',
           marginBottom: '0.25rem',
         },
-        // Tailwind doesn't style h4+ at all so this makes them look like headers
-        'h4, h5, h6' : {
-          fontWeight: 'bold',
-        }
+        // Tailwind doesn't style h5 or h6 at all so this makes them look like headers
+        'h5, h6': {
+          color: 'var(--tw-prose-headings)',
+          fontWeight: '500',
+        },
       },
     },
     invert: {

--- a/styles/index.js
+++ b/styles/index.js
@@ -84,12 +84,9 @@ const themeExtensions = {
       css: {
         code: {
           fontWeight: '400',
-        },
-        'code::before': {
-          content: '',
-        },
-        'code::after': {
-          content: '',
+          '&::before, &::after': {
+            content: '',
+          }
         },
         'blockquote p:first-of-type::before': { content: 'none' },
         'blockquote p:first-of-type::after': { content: 'none' },
@@ -101,6 +98,10 @@ const themeExtensions = {
           marginTop: '0.25rem',
           marginBottom: '0.25rem',
         },
+        // Tailwind doesn't style h4+ at all so this makes them look like headers
+        'h4, h5, h6' : {
+          fontWeight: 'bold',
+        }
       },
     },
     invert: {


### PR DESCRIPTION
This adds CSS styles for h4/h5/h6 so that they look like headers in the text.

It also consolidates one CSS rule, mostly so that I can validate with @stevejpurves that this JS-based configuration lets us write the same kind of structures that work in SCSS/SASS. Is that right Steve?

- closes #389 