### PR TITLE
🔑 Fix react keys error message for backmatter parts

### DIFF
--- a/.changeset/stale-camels-count.md
+++ b/.changeset/stale-camels-count.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': patch
+---
+
+The backmatter parts did not have a key, leading to a react error message

--- a/packages/site/src/components/Backmatter.tsx
+++ b/packages/site/src/components/Backmatter.tsx
@@ -1,6 +1,5 @@
-import type { GenericParent } from 'myst-common';
-import { ContentBlocks } from './ContentBlocks.js';
-import { HashLink } from 'myst-to-react';
+import type { GenericNode, GenericParent } from 'myst-common';
+import { HashLink, MyST } from 'myst-to-react';
 import type { KnownParts } from '../utils.js';
 
 export function BackmatterParts({ parts }: { parts: KnownParts }) {
@@ -14,6 +13,21 @@ export function BackmatterParts({ parts }: { parts: KnownParts }) {
       />
     </>
   );
+}
+
+/**
+ * This returns the contents of a part that we want to render (not the root or block, which are already wrapped)
+ * This also fixes a bug that the key is not defined on a block.
+ */
+function getChildren(content?: GenericParent): GenericNode | GenericNode[] {
+  if (
+    content?.type === 'root' &&
+    content.children?.length === 1 &&
+    content.children[0].type === 'block'
+  ) {
+    return content.children[0].children as GenericNode[];
+  }
+  return content as GenericNode;
 }
 
 export function Backmatter({
@@ -35,11 +49,8 @@ export function Backmatter({
         {title}
         <HashLink id={id} title={`Link to ${title}`} hover className="ml-2" />
       </h2>
-      <div className="grow">
-        <ContentBlocks
-          mdast={content}
-          className="opacity-90 group-hover/backmatter:opacity-100 col-screen"
-        />
+      <div className="grow opacity-90 group-hover/backmatter:opacity-100 col-screen">
+        <MyST ast={getChildren(content)} />
       </div>
     </div>
   );


### PR DESCRIPTION
This also removes unnecessary `div`s from the part rendering.