### PR TITLE
🐛 Styles overridden

### DIFF
--- a/.changeset/hot-papayas-end.md
+++ b/.changeset/hot-papayas-end.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/styles': patch
+---
+
+Fix style over-rides

--- a/styles/backmatter.css
+++ b/styles/backmatter.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @layer base {
   #footnotes p {
     margin: 0.25rem;

--- a/styles/block-styles.css
+++ b/styles/block-styles.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @layer base {
   .shaded {
     @apply pt-5 my-5 bg-slate-100 dark:bg-slate-800;

--- a/styles/cross-references.css
+++ b/styles/cross-references.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @layer base {
   .popout > h1,
   .popout > h2,

--- a/styles/grid-system.css
+++ b/styles/grid-system.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @layer base {
   .article-grid {
     @apply grid content-start grid-cols-article-sm md:grid-cols-article-md lg:grid-cols-article-lg xl:grid-cols-article-xl 2xl:grid-cols-article-2xl;

--- a/styles/tasklists.css
+++ b/styles/tasklists.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @layer base {
   .task-list-item {
     @apply list-none;


### PR DESCRIPTION
This fixes a style bug where the link styles get overridden by recent back-matter changes.

We only need to include the following once:

```
@tailwind base;
@tailwind components;
@tailwind utilities;
```